### PR TITLE
Revert "feat: add docs.local for confidential documents"

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -236,23 +236,3 @@ When including queries in documentation:
 3. **Add context comments**: Explain what the query measures
 4. **Note data period**: Clearly state the time period analyzed
 5. **Document optimization**: Mention any performance optimizations applied
-
-## Design Documents
-
-Confidential design documents are stored in `~/dotfiles/docs.local/`. This directory is git-ignored and remains local-only.
-
-### Referencing Design Documents
-
-When working on implementation tasks, check for relevant design documents:
-
-```bash
-ls ~/dotfiles/docs.local/
-```
-
-Read design documents to understand architecture decisions, API specifications, data models, and integration patterns before implementing features.
-
-### File Naming Convention
-
-- `<project>-<feature>.md` for feature designs
-- `<project>-architecture.md` for architecture overviews
-- `<topic>-guide.md` for cross-project guidelines

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 # Claude Code local settings
 .claude/settings.local.json
-
-# Local-only documents (confidential, not tracked)
-docs.local/

--- a/README.md
+++ b/README.md
@@ -60,19 +60,6 @@ Then run the install script:
     └── sync.md            # /sync command
 ```
 
-### Local-Only Documents
-
-The `docs.local/` directory is for confidential design documents that should not be committed to the repository. This directory is git-ignored.
-
-When using Dev Containers with the dotfiles feature enabled, `~/dotfiles/docs.local/` becomes accessible from within containers, allowing Claude Code to reference design documents as context.
-
-```text
-~/dotfiles/
-└── docs.local/            # Git-ignored, local only
-    ├── project-feature.md
-    └── project-architecture.md
-```
-
 ### Requirements
 
 - Git


### PR DESCRIPTION
## Summary

Revert the docs.local directory feature added in #3.

## Motivation

Confidential documents should be managed in a dedicated `docs` repository
rather than in dotfiles. The dotfiles repository's responsibility is to
manage configuration files, not to store documents that aren't deployed
anywhere.

🤖 Generated with [Claude Code](https://claude.ai/code)