### PR TITLE
fix: add priority rules and enhance PR guidelines

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,15 @@
 # Claude Code Configuration
 
+## Priority Rules
+
+User-level settings and instructions take precedence over project-level ones:
+
+- `~/.claude/CLAUDE.md` overrides `.claude/CLAUDE.md` or `CLAUDE.md`
+- `~/.claude/commands/` overrides `.claude/commands/` (same filename)
+- `~/.claude/skills/` overrides `.claude/skills/` (same filename)
+
+When conflicts exist, always follow user-level instructions.
+
 ## Code Quality
 
 ### Refactoring Principles

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -47,11 +47,26 @@ gh pr view
 
 ## PR Guidelines
 
+### Template
+
+**MUST check for project PR template first:**
+
+```bash
+cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || cat .github/pull_request_template.md 2>/dev/null || cat PULL_REQUEST_TEMPLATE.md 2>/dev/null || cat pull_request_template.md 2>/dev/null || cat docs/PULL_REQUEST_TEMPLATE.md 2>/dev/null || cat docs/pull_request_template.md 2>/dev/null
+```
+
+If a template exists, use it as the structure for the PR description. Only use the default structure below if no template exists.
+
 ### Title
 
-- MUST match the commit message subject line exactly
+- MUST match a commit message subject line exactly
+- If multiple commits exist, ask the user which commit message to use as the PR title
 
-### Description Structure
+### Draft or Ready
+
+- Ask the user whether to create the PR as a draft or ready for review
+
+### Description Structure (Default - only if no template exists)
 
 ```markdown
 ## Summary
@@ -74,6 +89,18 @@ Why are these changes needed?
 - [ ] Documentation updated
 - [ ] Breaking changes documented
 ```
+
+### Writing Style
+
+Determine the language based on the template used:
+
+1. **If a project PR template exists**: Match the language of the template
+2. **If using the default template above**: Write in English
+
+When writing in Japanese:
+
+- Use polite Japanese (敬語)
+- MUST invoke the `text-formatting-ja` skill
 
 ### Signature
 


### PR DESCRIPTION
## Summary

Added explicit priority rules for user-level vs project-level settings and enhanced PR creation guidelines.

## Motivation

The following issues were occurring:

- Project-level commands were overriding user-level commands without user confirmation, causing unexpected behavior (e.g., `/commit` command rules being ignored)
- PR templates were not being detected and used

## Changes

### CLAUDE.md
- Added priority rules section
- Clarified that user-level settings (`~/.claude/`) take precedence over project-level ones

### publish.md
- Added project PR template detection
- Added guidelines for PR title selection when multiple commits exist
- Added draft vs ready-for-review option
- Added Japanese text style guidelines (polite language, `text-formatting-ja` skill)

## Testing

- [x] Configuration file syntax verified
- [x] Changes reviewed for correctness

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated

---

🤖 Generated with [Claude Code](https://claude.ai/code)