### PR TITLE
refactor: extract coding standards into rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,17 +10,6 @@ User-level settings and instructions take precedence over project-level ones:
 
 When conflicts exist, always follow user-level instructions.
 
-## Code Quality
-
-### Refactoring Principles
-
-When refactoring code:
-
-- Prioritize readability over cleverness
-- Prioritize maintainability over brevity
-- Ensure changes are testable
-- Preserve existing behavior unless explicitly changing it
-
 ## Professional Engineering Principles
 
 ### Decision Making
@@ -29,13 +18,6 @@ When refactoring code:
 - Maintain broad perspective - understand system-wide implications
 - Take ownership - make independent professional judgments
 - Don't defer unnecessarily - provide expert recommendations
-
-### Code Changes
-
-- Consider backward compatibility
-- Assess performance implications
-- Think about edge cases and error handling
-- Plan for future maintainability
 
 ### Communication
 

--- a/.claude/rules/coding-standards.md
+++ b/.claude/rules/coding-standards.md
@@ -1,0 +1,25 @@
+# Coding Standards
+
+Apply when writing or reviewing code.
+
+## Naming
+
+- Names must convey domain meaning - avoid generic names like `base_query`, `data`, `result`, `tmp`
+- When uncertain about naming or patterns, investigate the codebase first
+
+## Design
+
+- Keep functions and classes focused on a single responsibility
+- Prioritize readability over cleverness
+- Prioritize maintainability over brevity
+- Preserve existing behavior unless explicitly changing it
+- Maintain consistency across related files and similar patterns
+
+## Quality
+
+- Never compromise quality for CI cost or time savings
+- Ensure changes are testable
+- Consider backward compatibility
+- Assess performance implications
+- Think about edge cases and error handling
+- Plan for future maintainability


### PR DESCRIPTION
## Summary
Extract coding-related guidelines from CLAUDE.md into a dedicated rules file for better organization.

## Motivation
The coding standards were embedded in CLAUDE.md alongside other configuration. Moving them to `.claude/rules/coding-standards.md` aligns with the existing pattern where specific rules (commit-message, pr-description, etc.) have their own files.

## Changes
- Remove Code Quality and Code Changes sections from CLAUDE.md
- Add new `coding-standards.md` rules file covering naming, design, and quality guidelines

## Testing
- [ ] Verified rules file is properly loaded
- [x] Manual testing completed

## Checklist
- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)