### PR TITLE
docs: update README to reflect current structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,82 +2,88 @@
 
 Personal dotfiles for managing development environment configurations.
 
-## Claude Code Configuration
+## What's Included
 
-This repository manages Claude Code configuration files that can be installed globally on your machine.
+### Claude Code Configuration
 
-### What's Included
+Configuration files for Claude Code that can be installed globally.
 
 #### Global Configuration (`CLAUDE.md`)
-Personal preferences and conventions applied to all projects:
-- Commit message conventions (Conventional Commits format)
-- Code quality and refactoring guidelines
-- Japanese text formatting rules
-- Pull request guidelines
-- Professional engineering principles
 
-#### Custom Slash Commands
-Reusable workflows available across all projects:
+Professional engineering principles for decision making and communication.
 
-- **`/commit`** - Systematic commit and PR workflow
-  - Creates feature branches if on master/main
-  - Guides through Conventional Commits format
-  - Creates or updates pull requests automatically
+#### Rules
 
-- **`/fixup`** - Interactive rebase and fixup workflow
-  - Creates fixup commits for specific hashes
-  - Uses `git rebase -i --autosquash`
-  - Safely force pushes with `--force-with-lease`
+Standards automatically applied based on context:
 
-- **`/sync`** - Sync feature branch with master/main
-  - Rebases current branch on latest master/main
-  - Guides through conflict resolution
-  - Force pushes safely after successful rebase
+- **commit-message** - Conventional Commits format
+- **pr-description** - Pull request structure and conventions
+- **coding-standards** - Naming, design, and quality guidelines
+- **document-writing** - Writing style and consistency
+- **text-formatting-ja** - Japanese text formatting
 
-### Installation
+#### Slash Commands
 
-Clone this repository:
+- **`/commit`** - Create commits with Conventional Commits format
+- **`/fixup`** - Create fixup commits and autosquash rebase
+- **`/publish`** - Push commits and create/update pull requests
+- **`/sync`** - Sync feature branch with main via rebase
+
+#### Skills
+
+- **technical-writing** - Technical document creation (design docs, specs)
+- **data-querying** - SQL query development with BigQuery
+- **analytics-design** - Looker Studio report design
+
+### mise Configuration
+
+Global mise configuration template (`~/.config/mise/config.toml`).
+
+## Installation
 
 ```bash
 gh repo clone yusuke-suzuki/dotfiles ~/dotfiles
 cd ~/dotfiles
-```
-
-Then run the install script:
-
-```bash
 ./install.sh
 ```
 
 ### What Gets Installed
 
-```
+```text
 ~/.claude/
-├── CLAUDE.md              # Global configuration and conventions
-└── commands/
-    ├── commit.md          # /commit command
-    ├── fixup.md           # /fixup command
-    └── sync.md            # /sync command
+├── CLAUDE.md
+├── commands/
+│   ├── commit.md
+│   ├── fixup.md
+│   ├── publish.md
+│   └── sync.md
+├── rules/
+│   ├── coding-standards.md
+│   ├── commit-message.md
+│   ├── document-writing.md
+│   ├── pr-description.md
+│   └── text-formatting-ja.md
+└── skills/
+    ├── analytics-design/
+    ├── data-querying/
+    └── technical-writing/
+
+~/.config/mise/
+└── config.toml
 ```
 
 ### Requirements
 
 - Git
 - GitHub CLI (`gh`)
-
-### Notes
-
-- Existing `~/.claude/CLAUDE.md` is automatically backed up before installation
-- Commands are intentionally generic (no project-specific lint checks)
-- Add project-specific quality checks in project's local `CLAUDE.md` if needed
-- All commands follow best practices (e.g., `--force-with-lease` over `--force`)
+- mise
 
 ### Updating
-
-Pull the latest changes and re-run the install script:
 
 ```bash
 cd ~/dotfiles
 git pull
 ./install.sh
 ```
+
+Existing files are automatically backed up before installation.


### PR DESCRIPTION
## Summary

Update README to document the current repository structure, including rules, skills, publish command, and mise configuration that were previously undocumented.

## Motivation

The README was outdated and did not reflect recent additions to the dotfiles repository.

## Changes

- Add documentation for rules directory (coding-standards, commit-message, document-writing, pr-description, text-formatting-ja)
- Add documentation for skills directory (technical-writing, data-querying, analytics-design)
- Add `/publish` command to slash commands list
- Add mise configuration section
- Update installation directory tree to reflect current structure
- Add mise to requirements
- Simplify and reorganize content structure

## Testing

- [x] Verified directory structure matches documentation

## Checklist

- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)