### PR TITLE
docs: improve document writing rules and skills

### DIFF
--- a/.claude/rules/document-writing.md
+++ b/.claude/rules/document-writing.md
@@ -2,20 +2,43 @@
 
 Apply when writing or editing documents.
 
+## Structural Integrity
+
+A document is not a collection of independent sections but a logically coherent narrative. Each section should build on previous sections, and all content should serve the document's central argument or purpose.
+
+### Principles for Modifications
+
+1. **Read the entire document before editing** - Understand the overall structure and argument before making partial changes
+2. **Consider impact on the narrative** - Evaluate how modifications affect the logical flow of the entire document
+3. **Update all related occurrences** - Search the entire document for terms/expressions being modified and update all instances
+4. **Remove obsolete sections** - Actively delete sections that become redundant or unnecessary after modifications
+
+## Content Verification
+
+All code and queries in documents must be verified before inclusion.
+
+- SQL: Validate syntax with `bq query --dry_run`, execute to confirm, and include actual results
+- Code: Include only in executable state
+- Never fabricate data
+
+## Data-Driven
+
+- Include real data, not hypotheticals
+- Define KPIs with baselines and targets
+- Quantify impact (counts, costs, time)
+
+## Diagrams
+
+Use Mermaid notation for diagrams. Do not use ASCII art.
+
 ## Writing Style
 
 Write naturally. Avoid:
 
 - Bullet lists where prose flows better
-- Emphasis phrases ("This is important because...", "It's worth noting...")
+- Exaggerated or emphatic expressions:
+  - "revolutionary", "game-changing", "seamless", "robust", "cutting-edge"
+  - "very", "extremely", "significantly" (without quantitative evidence)
+  - "This is important because...", "It's worth noting...", "Crucially..."
 - Repeating information
-
-## Document Consistency
-
-When modifying documents:
-
-1. Identify change scope
-2. Check related sections
-3. Update all references simultaneously
-
-Applies to: metrics, cross-references, repeated terms/values.
+- Vague expressions (overuse of "etc.", "such as", "and so on")

--- a/.claude/skills/data-querying/SKILL.md
+++ b/.claude/skills/data-querying/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: data-querying
-description: Write and verify SQL queries with BigQuery. Use when executing bq commands, writing SQL queries, or including query results in documents.
+description: Write and verify SQL queries with BigQuery. Use when executing bq commands, writing SQL queries, or including query results in documents. Trigger on "bq", "BigQuery", "query".
 ---
 
 # Data Querying
-
-## Verification Requirement
-
-All queries MUST be executed with `bq` and verified before inclusion. Never include unverified queries or fabricated data.
 
 ## Query Process
 
@@ -34,8 +30,6 @@ All queries MUST be executed with `bq` and verified before inclusion. Never incl
 - Avoid correlated subqueries (use JOINs/CTEs)
 - Filter early with CTEs before joining large tables
 
-## Documentation
+## Authentication
 
-1. Execute exact query with `bq`
-2. Copy real output only
-3. State time period and what query measures
+If `bq query` fails with authentication error, prompt user to run `gcloud auth login` and resume after login.

--- a/.claude/skills/technical-writing/SKILL.md
+++ b/.claude/skills/technical-writing/SKILL.md
@@ -7,35 +7,23 @@ description: Write technical design documents (design docs, specs, proposals). U
 
 ## Workflow
 
-1. **Context Gathering**: Understand the problem, stakeholders, constraints
-2. **Structure Selection**: Choose appropriate template based on document type
-3. **Data Collection**: Gather metrics, run queries, collect evidence
-4. **Drafting**: Write section by section, starting with unknowns
-5. **Verification**: Validate all data and queries are accurate
+1. **Understand context**: Problem, stakeholders, constraints
+2. **Choose template**: Based on document type
+3. **Write**: Section by section
 
 ## Document Templates
 
 See [references/templates.md](references/templates.md) for:
 
-- Design Doc (問題解決型)
-- Report Design (レポート設計型)
+- Design Doc
 
 ## Key Principles
 
-### Data-Driven
+### Data-Driven Decision Making
 
-- Include real data, not hypotheticals
-- Show SQL queries with actual results
-- Define measurable KPIs with baselines and targets
-
-### Scope Clarity
-
-- Explicit "スコープ外" section
-- Document what you're NOT doing and why
-- Prevents scope creep and sets expectations
+Base design decisions on real data, not assumptions.
 
 ### Problem First
 
 - Start with the problem, not the solution
-- Quantify the impact (件数, コスト, 時間)
 - Make the "why" compelling before the "how"


### PR DESCRIPTION
## Summary

Consolidate document quality rules into rules/document-writing.md to ensure they are always applied. Remove duplicate content from skills and simplify workflows.

## Motivation

Document quality rules were scattered across skills, which are not always invoked. Moving them to rules ensures consistent application.

## Changes

- Add structural integrity, content verification, and writing style rules to `rules/document-writing.md`
- Remove duplicate rules from `skills/data-querying/SKILL.md` and `skills/technical-writing/SKILL.md`
- Simplify workflows in skills
- Add authentication error handling guidance to data-querying skill

## Testing

- [x] Manual testing completed

## Checklist

- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)