### PR TITLE
feat: add Claude Code project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh issue view:*)",
+      "Bash(bq show:*)",
+      "Bash(bq ls:*)"
+    ]
+  },
+  "enabledPlugins": {
+    "example-skills@anthropic-agent-skills": true
+  }
+}


### PR DESCRIPTION
## Summary

Add Claude Code project settings to configure permissions and enable plugins.

## Motivation

Streamline Claude Code workflow by pre-authorizing safe read-only commands for GitHub CLI and BigQuery CLI, and enabling the example-skills plugin.

## Changes

- Add `.claude/settings.json` with permissions for `gh pr view`, `gh pr diff`, `gh pr checks`, `gh run view`, `gh issue view`, `bq show`, and `bq ls`
- Enable `example-skills@anthropic-agent-skills` plugin

## Testing

- [x] Manual testing completed

## Checklist

- [x] Follows style guidelines

🤖 Generated with [Claude Code](https://claude.ai/code)