### PR TITLE
feat: add resolve-comments command

### DIFF
--- a/.claude/commands/resolve-comments.md
+++ b/.claude/commands/resolve-comments.md
@@ -1,0 +1,80 @@
+---
+description: Resolve PR review comments
+allowed-tools: Bash(gh pr view:*), Bash(gh api:*), Read, Glob, Edit, Write
+---
+
+# Resolve Comments
+
+You are assisting with resolving PR review comments. Follow these steps:
+
+## 1. Fetch Review Comments
+
+Use `/pr-comments` to display comments in a readable format.
+
+Then, for actions that require thread IDs (reply/resolve), fetch via GraphQL:
+
+```bash
+gh api graphql -f query='
+query {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: NUMBER) {
+      reviewThreads(first: 50) {
+        nodes {
+          id
+          isResolved
+          comments(first: 10) {
+            nodes {
+              databaseId
+              body
+              path
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+## 2. Analyze and Propose Response
+
+For each unresolved comment, analyze the feedback and make a professional judgment:
+
+1. **Assess validity**: Is the feedback technically correct? Does it improve the code?
+2. **Evaluate trade-offs**: Consider complexity, scope, and practical impact
+3. **Propose action**: Recommend either fixing or explaining why no change is needed
+
+Present your analysis and recommendation to the user for each comment. The user makes the final decision, but you should provide clear reasoning for your recommendation.
+
+## 3. Handle Response
+
+**If fix required:**
+
+- Make the necessary code changes
+- Inform user to use `/fixup` or `/commit` after all fixes are complete
+
+**If no action needed:**
+
+- Draft a reply with clear rationale (e.g., "Won't fix because...", "Intentional design because...")
+- **Match the language of the original comment** (e.g., reply in Japanese if the comment is in Japanese)
+- Reply to the last comment in the thread (use its `databaseId` as `comment_id`)
+- Post the reply: `gh api /repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -X POST -f body="..."`
+- Resolve the thread:
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+## 4. Summary
+
+After processing all comments:
+
+- List what was fixed (if any)
+- List what was resolved without changes (if any)
+- Suggest next steps (e.g., `/fixup` to amend, `/publish` to push)

--- a/.claude/skills/analytics-design/SKILL.md
+++ b/.claude/skills/analytics-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analytics-design
-description: Design Looker Studio reports and dashboards. Use when creating Looker Studio reports, designing data sources, or writing visualization specifications. Trigger on "Looker Studio", "レポート設計", "ダッシュボード".
+description: Design Looker Studio reports and dashboards. Use when creating Looker Studio reports, designing data sources, or writing visualization specifications.
 ---
 
 # Analytics Design

--- a/.claude/skills/technical-writing/SKILL.md
+++ b/.claude/skills/technical-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-writing
-description: Write technical design documents (design docs, specs, proposals). Use when creating design documents, technical specifications, project proposals, or similar structured technical content. Trigger on "design doc", "デザインドック", "設計書", "仕様書", "proposal".
+description: Write technical design documents (design docs, specs, proposals). Use when creating design documents, technical specifications, project proposals, or similar structured technical content.
 ---
 
 # Technical Writing

--- a/README.md
+++ b/README.md
@@ -6,38 +6,14 @@ Personal dotfiles for managing development environment configurations.
 
 ### Claude Code Configuration
 
-Configuration files for Claude Code that can be installed globally.
-
-#### Global Configuration (`CLAUDE.md`)
-
-Professional engineering principles for decision making and communication.
-
-#### Rules
-
-Standards automatically applied based on context:
-
-- **commit-message** - Conventional Commits format
-- **pr-description** - Pull request structure and conventions
-- **coding-standards** - Naming, design, and quality guidelines
-- **document-writing** - Writing style and consistency
-- **text-formatting-ja** - Japanese text formatting
-
-#### Slash Commands
-
-- **`/commit`** - Create commits with Conventional Commits format
-- **`/fixup`** - Create fixup commits and autosquash rebase
-- **`/publish`** - Push commits and create/update pull requests
-- **`/sync`** - Sync feature branch with main via rebase
-
-#### Skills
-
-- **technical-writing** - Technical document creation (design docs, specs)
-- **data-querying** - SQL query development with BigQuery
-- **analytics-design** - Looker Studio report design
+- **CLAUDE.md** - Professional engineering principles
+- **commands/** - Slash commands for common workflows
+- **rules/** - Standards automatically applied based on context
+- **skills/** - Specialized capabilities for specific tasks
 
 ### mise Configuration
 
-Global mise configuration template (`~/.config/mise/config.toml`).
+Global mise configuration template.
 
 ## Installation
 
@@ -53,20 +29,8 @@ cd ~/dotfiles
 ~/.claude/
 ├── CLAUDE.md
 ├── commands/
-│   ├── commit.md
-│   ├── fixup.md
-│   ├── publish.md
-│   └── sync.md
 ├── rules/
-│   ├── coding-standards.md
-│   ├── commit-message.md
-│   ├── document-writing.md
-│   ├── pr-description.md
-│   └── text-formatting-ja.md
 └── skills/
-    ├── analytics-design/
-    ├── data-querying/
-    └── technical-writing/
 
 ~/.config/mise/
 └── config.toml

--- a/install.sh
+++ b/install.sh
@@ -128,16 +128,25 @@ done
 echo "  - $MISE_CONFIG_DIR/config.toml"
 echo ""
 echo "Claude Code commands:"
-echo "  /commit  - Create a git commit with Conventional Commits format"
-echo "  /fixup   - Create a fixup commit and autosquash rebase"
-echo "  /publish - Push commits and create/update pull request"
-echo "  /sync    - Sync feature branch with main via rebase"
+for cmd_file in "$COMMANDS_DIR"/*.md; do
+    if [ -f "$cmd_file" ]; then
+        cmd_name=$(basename "$cmd_file" .md)
+        description=$(grep -m1 "^description:" "$cmd_file" | sed 's/^description:[[:space:]]*//')
+        printf "  /%-16s - %s\n" "$cmd_name" "$description"
+    fi
+done
 echo ""
 echo "Claude Code skills:"
-echo "  technical-writing  - Technical document creation"
-echo "  data-querying      - SQL query development with BigQuery"
-echo "  analytics-design   - Analytics infrastructure design"
-echo "  text-formatting-ja - Japanese text formatting"
+for skill_dir in "$SKILLS_DIR"/*/; do
+    if [ -d "$skill_dir" ]; then
+        skill_name=$(basename "$skill_dir")
+        skill_file="$skill_dir/SKILL.md"
+        if [ -f "$skill_file" ]; then
+            description=$(grep -m1 "^description:" "$skill_file" | sed 's/^description:[[:space:]]*//')
+            printf "  %-18s - %s\n" "$skill_name" "$description"
+        fi
+    fi
+done
 echo ""
 echo "mise setup:"
 echo "  Add the following to your shell config (e.g., ~/.bashrc, ~/.zshrc):"


### PR DESCRIPTION
## Summary

Add a new slash command `/resolve-comments` to handle PR review comments, along with related improvements.

## Motivation

Streamline the workflow for responding to PR review comments by providing a structured command that guides through the process of replying and resolving threads.

## Changes

- Add `.claude/commands/resolve-comments.md` with instructions for:
  - Fetching review comments using `/pr-comments` and GraphQL
  - Analyzing feedback and proposing responses with clear rationale
  - Posting replies in the same language as the original comment
  - Resolving threads via GraphQL mutation
- Update `install.sh` to dynamically read command/skill descriptions from frontmatter
- Simplify `README.md` by removing detailed file listings (now shown by install.sh)
- Remove Japanese triggers from skill descriptions (redundant for LLM interpretation)

## Testing

- [x] Manual testing completed

## Checklist

- [x] Follows style guidelines

🤖 Generated with [Claude Code](https://claude.ai/code)