### PR TITLE
docs: add sentence completion rule

### DIFF
--- a/.claude/rules/text-formatting-ja.md
+++ b/.claude/rules/text-formatting-ja.md
@@ -16,6 +16,13 @@ Use half-width `()`:
 - OK: `ユーザー (User) が追加されました`
 - NG: `ユーザー（User）が追加されました`
 
+## Sentence Completion
+
+Complete sentences properly. Don't end with colons:
+
+- OK: `テーブル間の関係をまとめると以下のようになります。`
+- NG: `テーブル間の関係をまとめると:`
+
 ## Scope
 
 Do NOT modify: backticks, database values, API responses.


### PR DESCRIPTION
## Summary

Add a new "Sentence Completion" section to the Japanese text formatting rules, guiding writers to complete sentences properly rather than ending with colons.

## Motivation

Japanese text should follow natural sentence structure. Ending sentences with colons (`:`) instead of proper punctuation (like `。`) creates incomplete sentences that don't read naturally.

## Changes

- Add "Sentence Completion" section to text-formatting-ja.md with OK/NG examples

## Testing

- [x] Verified markdown renders correctly

## Checklist

- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)