### PR TITLE
docs: add markdown link spacing rule

### DIFF
--- a/.claude/rules/text-formatting-ja.md
+++ b/.claude/rules/text-formatting-ja.md
@@ -4,10 +4,12 @@ Apply to all Japanese prose text (documents, comments, descriptions).
 
 ## Spacing
 
-Add half-width spaces around alphanumeric/English:
+Add half-width spaces around alphanumeric/English and markdown links:
 
 - OK: `追加された権限 (18 件)`
 - NG: `追加された権限（18件）`
+- OK: `詳しくは [ガイド](./guide.md) を参照`
+- NG: `詳しくは[ガイド](./guide.md)を参照`
 
 ## Parentheses
 


### PR DESCRIPTION
## Summary

Add a spacing rule for markdown links in Japanese text formatting guidelines.

## Motivation

When markdown links appear inline with Japanese characters without spacing, readability decreases. This rule ensures consistent formatting.

## Changes

- Add spacing rule around markdown links with OK/NG examples

## Testing

- [x] Manual review of the formatting rule

## Checklist

- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)