### PR TITLE
docs: clarify documents as deliverables

### DIFF
--- a/.claude/rules/document-writing.md
+++ b/.claude/rules/document-writing.md
@@ -12,6 +12,14 @@ When modifying a document:
 2. **Update all affected sections** - When the story changes, maintain consistency throughout
 3. **Remove obsolete content** - Delete content that becomes redundant after modifications
 
+Documents are deliverables, not workspaces. Never add:
+
+- Progress tracking sections ("Next Steps", "TODO", checklists)
+- Claude's internal notes or reminders
+- Meta-commentary about the writing process
+
+Use the TodoWrite tool for task management instead.
+
 ## Content Verification
 
 All code and queries in documents must be verified before inclusion.


### PR DESCRIPTION
## Summary

Add guidance to the document-writing rules clarifying that documents are deliverables, not workspaces. Documents should not contain progress tracking sections, internal notes, or meta-commentary.

## Motivation

Reinforces the principle that task management belongs in tools like TodoWrite, keeping documents clean and focused on their intended purpose as final deliverables.

## Changes

- Add new section to document-writing.md specifying what should not appear in documents
- Reference TodoWrite as the appropriate tool for task tracking

## Testing

- [x] Reviewed markdown rendering
- [x] Verified consistency with existing document guidelines

## Checklist

- [x] Follows style guidelines
- [x] Documentation is self-contained

🤖 Generated with [Claude Code](https://claude.ai/code)