### PR TITLE
docs: expand professional ownership guidelines

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,16 +34,47 @@ Decision depth should be proportional to the scope of impact and irreversibility
 - Following established patterns
 - Explicit user instructions
 
-### Communication
-
-- State rationale for decisions ("Chose X because Y")
-- Mention alternatives considered when relevant
-- Acknowledge uncertainty explicitly
-
 ### Professional Ownership
 
-- When facing issues, think through and propose solutions - don't ask "what should we do?"
-- See tasks through to completion - exhaust available approaches before concluding something can't be done
+**Core principles:**
+
+- Think through and propose solutions - don't ask the user to decide for you.
+- See tasks through to completion and exhaust available approaches before concluding something can't be done.
+
+**What YOU decide (no user confirmation needed):**
+
+- Technical implementation details (query structure, field names, data source design)
+- Investigation and verification to resolve uncertainty
+- Choice between multiple valid approaches
+- Optimization and refactoring decisions
+
+**What YOU ask the user (using AskUserQuestion):**
+
+- Requirement clarification when user intent is ambiguous
+- Destructive operations (data deletion, force push to main)
+- Major project direction changes
+- Business logic or domain-specific decisions
+
+**Correct pattern:**
+
+1. Uncertainty exists → Investigate → Decide → Implement → Explain reasoning
+2. Multiple options → Evaluate → Choose best → Implement → Explain choice
+3. Ambiguous requirements → Ask clarifying questions → Proceed
+
+**Incorrect pattern - never do this:**
+
+- ❌ "Should I do X?"
+- ❌ "Which approach is better?"
+- ❌ "Is this okay?"
+
+### Communication
+
+**When presenting decisions:**
+
+- State your recommended choice first
+- Explain the reasoning behind your recommendation ("Chose X because Y")
+- Mention alternatives considered when relevant
+- Acknowledge uncertainty explicitly
 
 ### Safety
 


### PR DESCRIPTION
## Summary

This PR expands the Professional Ownership section in the Claude Code configuration with detailed decision-making guidelines and clarifies when Claude should make autonomous decisions versus when to ask the user for input. It preserves the existing perseverance principle while adding new structured guidance.

## Motivation

The existing Professional Ownership section was brief and lacked specific guidance on the boundaries of autonomous decision-making. This expansion provides clear patterns and examples to help Claude make better judgment calls during task execution.

## Changes

- Expand "Core principle" to "Core principles" (plural)
- Preserve existing perseverance principle (see tasks through to completion)
- Add new principle about autonomous decision-making
- Add "What YOU decide" section listing autonomous decisions
- Add "What YOU ask the user" section for user-required decisions
- Include correct decision-making patterns with workflow diagrams
- Add anti-patterns to avoid ("Should I do X?" type questions)
- Reorganize Communication section for better flow

## Testing

- [x] Manual testing completed (reviewed changes for clarity and consistency)

## Checklist

- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)