### PR TITLE
refactor: remove path targeting from rules

### DIFF
--- a/.claude/rules/document-writing.md
+++ b/.claude/rules/document-writing.md
@@ -1,7 +1,3 @@
----
-paths: ["*.md"]
----
-
 # Document Writing
 
 Apply when writing or editing documents.

--- a/.claude/rules/text-formatting-ja.md
+++ b/.claude/rules/text-formatting-ja.md
@@ -1,7 +1,3 @@
----
-paths: ["*.md"]
----
-
 # Japanese Text Formatting
 
 Apply to all Japanese prose text (documents, comments, descriptions).


### PR DESCRIPTION
## Summary
Removes path restrictions from `document-writing` and `text-formatting-ja` rules to apply them when writing GitHub PR descriptions, issue comments, and other non-file content.

## Motivation
Previously, these rules only applied to `.md` files due to `paths: ["*.md"]` targeting. This prevented them from being used when writing PR descriptions or issue comments, where they would also be valuable.

## Changes
- Removed frontmatter path targeting from `.claude/rules/document-writing.md`
- Removed frontmatter path targeting from `.claude/rules/text-formatting-ja.md`

🤖 Generated with [Claude Code](https://claude.ai/code)