### PR TITLE
refactor: remove disable-model-invocation from skills

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -2,7 +2,6 @@
 name: commit
 description: Create a git commit with Conventional Commits format
 allowed-tools: Bash(git status:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Read, Glob
-disable-model-invocation: true
 ---
 
 # Commit

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -2,7 +2,6 @@
 name: publish
 description: Push commits and create/update pull request
 allowed-tools: Bash(git status:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(gh pr edit:*), Read, Glob
-disable-model-invocation: true
 ---
 
 # Publish

--- a/.claude/skills/resolve-comments/SKILL.md
+++ b/.claude/skills/resolve-comments/SKILL.md
@@ -2,7 +2,6 @@
 name: resolve-comments
 description: Resolve PR review comments
 allowed-tools: Bash(gh pr view:*), Bash(gh api:*), Read, Glob, Edit, Write
-disable-model-invocation: true
 ---
 
 # Resolve Comments

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -2,7 +2,6 @@
 name: sync
 description: Sync feature branch with main via rebase
 allowed-tools: Bash(git status:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(git rebase:*)
-disable-model-invocation: true
 ---
 
 # Sync


### PR DESCRIPTION
## Summary

Remove disable-model-invocation flag from commit, publish, resolve-comments, and sync skills to allow skill invocation from chat conversations and Skill tool calls.

## Motivation

With disable-model-invocation enabled, skills could not be invoked via chat requests like "call this skill" or through the Skill tool, limiting their usability.

## Changes

- Removed disable-model-invocation flag from commit/SKILL.md
- Removed disable-model-invocation flag from publish/SKILL.md
- Removed disable-model-invocation flag from resolve-comments/SKILL.md
- Removed disable-model-invocation flag from sync/SKILL.md

## Testing

- [x] Manual testing completed (verified skills can be invoked)
- [ ] Tests added/updated (N/A)

## Checklist

- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)