### PR TITLE
feat: add lint-doc skill for document style checking

### DIFF
--- a/.claude/skills/lint-doc/SKILL.md
+++ b/.claude/skills/lint-doc/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lint-doc
 description: Check documents against style rules and fix violations. Use after writing or editing documents to ensure compliance with document-writing and text-formatting-ja rules.
-allowed-tools: Read, Edit, Glob
+allowed-tools: Read, Glob
 ---
 
 # Document Linting

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: publish
 description: Push commits and create/update pull request
-allowed-tools: Bash(git status:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(gh pr view:*), Bash(gh pr create:*), Bash(gh pr edit:*), Read, Glob
+allowed-tools: Bash(git status:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(gh pr view:*), Read, Glob
 ---
 
 # Publish


### PR DESCRIPTION
## Summary
Add a new skill for checking and fixing document style violations after writing. Also tighten permission controls on skills that modify content or create PRs.

## Motivation
Document writing rules (document-writing.md, text-formatting-ja.md) are often ignored during content creation due to cognitive load. This skill separates the concerns: write first, then lint. This provides a multi-layered approach where some rules are followed during writing, and remaining violations are caught during linting.

Additionally, auto-allowed tools for destructive or content-modifying operations can lead to unreviewed changes. Removing these from allowed-tools ensures user confirmation before execution.

## Changes
- Add `lint-doc` skill that checks documents against existing style rules
- Remove `Edit` from lint-doc allowed-tools (require confirmation for fixes)
- Remove `gh pr create` and `gh pr edit` from publish allowed-tools (require confirmation for PR operations)

## Testing
- [x] Manual testing completed

## Checklist
- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)