### PR TITLE
refactor: integrate lint-doc into skills

### DIFF
--- a/.claude/skills/analysis-report/SKILL.md
+++ b/.claude/skills/analysis-report/SKILL.md
@@ -23,3 +23,5 @@ Use [references/analysis-report-template.md](references/analysis-report-template
 3. **Build Query**: Use `/bq-query` skill to design and execute queries.
    - Requirements and schema from Steps 1-2 provide context
    - Interpret results and document findings
+
+4. **Verify Style Compliance**: Use `/lint-doc <filename>` to check and fix style violations

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: commit
 description: Create a git commit with Conventional Commits format
-allowed-tools: Bash(git status:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Read, Glob
 ---
 
 # Commit

--- a/.claude/skills/fixup/SKILL.md
+++ b/.claude/skills/fixup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: fixup
 description: Create a fixup commit and autosquash rebase
-allowed-tools: Bash(git status:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git rebase:*), Read, Glob
 ---
 
 # Fixup

--- a/.claude/skills/lint-doc/SKILL.md
+++ b/.claude/skills/lint-doc/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: lint-doc
 description: Check documents against style rules and fix violations. Use after writing or editing documents to ensure compliance with document-writing and text-formatting-ja rules.
-allowed-tools: Read, Glob
 ---
 
 # Document Linting

--- a/.claude/skills/looker-studio-report/SKILL.md
+++ b/.claude/skills/looker-studio-report/SKILL.md
@@ -23,6 +23,8 @@ Use [references/looker-studio-template.md](references/looker-studio-template.md)
    - Align time granularity with usage frequency (daily/weekly/monthly)
    - Design data sources, pages, and charts
 
+4. **Verify Style Compliance**: Use `/lint-doc <filename>` to check and fix style violations
+
 ## Best Practices
 
 ### Reference Documentation

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: publish
 description: Push commits and create/update pull request
-allowed-tools: Bash(git status:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(gh pr view:*), Read, Glob
 ---
 
 # Publish

--- a/.claude/skills/resolve-comments/SKILL.md
+++ b/.claude/skills/resolve-comments/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: resolve-comments
 description: Resolve PR review comments
-allowed-tools: Bash(gh pr view:*), Bash(gh api:*), Read, Glob, Edit, Write
 ---
 
 # Resolve Comments

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: sync
 description: Sync feature branch with main via rebase
-allowed-tools: Bash(git status:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(git rebase:*)
 ---
 
 # Sync

--- a/.claude/skills/technical-writing/SKILL.md
+++ b/.claude/skills/technical-writing/SKILL.md
@@ -10,6 +10,7 @@ description: Write technical design documents (design docs, specs, proposals). U
 1. **Understand context**: Problem, stakeholders, constraints
 2. **Choose template**: Based on document type
 3. **Write**: Section by section
+4. **Verify style compliance**: Use `/lint-doc <filename>` to check and fix style violations
 
 ## Document Templates
 


### PR DESCRIPTION
## Summary

Remove invalid allowed-tools property from skill frontmatter and integrate automatic lint-doc verification into document creation workflows.

## Motivation

The `allowed-tools` property in skill frontmatter was non-functional. Additionally, document style compliance should be verified at draft stage to prevent structural issues that are difficult to fix after content expansion.

## Changes

- Remove `allowed-tools` from 6 skills (commit, fixup, sync, publish, resolve-comments, lint-doc)
- Add automatic lint-doc invocation to 3 document creation skills (technical-writing, analysis-report, looker-studio-report)

## Testing

- [ ] Manual testing completed

## Checklist

- [x] Follows style guidelines
- [ ] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)