### PR TITLE
feat: add always-on rules to .claude/rules/

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,4 +81,3 @@ Decision depth should be proportional to the scope of impact and irreversibility
 - Use `--help` and dry-run options to verify command behavior before execution
 - Run commands in isolated environments to prevent unintended side effects
 - When debugging external tool issues, prefer non-destructive verification methods (e.g., using read-only commands, checking logs, or inspecting state without making changes)
-- When editing content within code blocks (` ``` `) in documents, verify correctness by executing the code. This applies to every edit regardless of size — including renames, constant changes, and incremental modifications

--- a/.claude/rules/text-formatting-ja.md
+++ b/.claude/rules/text-formatting-ja.md
@@ -1,0 +1,30 @@
+# Japanese Text Formatting
+
+Apply to all Japanese prose text (documents, comments, descriptions).
+
+## Spacing
+
+Add half-width spaces around alphanumeric/English and markdown links:
+
+- OK: `追加された権限 (18 件)`
+- NG: `追加された権限（18件）`
+- OK: `詳しくは [ガイド](./guide.md) を参照`
+- NG: `詳しくは[ガイド](./guide.md)を参照`
+
+## Parentheses
+
+Use half-width `()`:
+
+- OK: `ユーザー (User) が追加されました`
+- NG: `ユーザー（User）が追加されました`
+
+## Sentence Completion
+
+Complete sentences properly. Don't end with colons:
+
+- OK: `テーブル間の関係をまとめると以下のようになります。`
+- NG: `テーブル間の関係をまとめると:`
+
+## Scope
+
+Do NOT modify: database values, API responses.

--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -1,0 +1,21 @@
+# Writing Style
+
+Apply to all text output (documents, PR descriptions, commit messages, comments).
+
+## Tone
+
+Write naturally. Avoid:
+
+- Exaggerated or emphatic expressions:
+  - "revolutionary", "game-changing", "seamless", "robust", "cutting-edge"
+  - "very", "extremely", "significantly" (without quantitative evidence)
+  - "This is important because...", "It's worth noting...", "Crucially..."
+- Repeating information
+- Vague expressions (overuse of "etc.", "such as", "and so on")
+
+## Style Consistency
+
+When editing existing text, match the established style:
+
+- **Japanese**: Match formality (です/ます vs である/だ). Never mix within the same context.
+- **English**: Match tone and voice (formal, casual, technical).

--- a/.claude/skills/lint-doc/rules/document-writing.md
+++ b/.claude/skills/lint-doc/rules/document-writing.md
@@ -12,6 +12,8 @@ When modifying a document:
 2. **Update all affected sections** - When the story changes, maintain consistency throughout
 3. **Remove obsolete content** - Delete content that becomes redundant after modifications
 
+Documents must be self-contained. Do not use relative links to other local files — they break when the document is shared outside the repository (e.g., Notion, Google Docs).
+
 Documents are deliverables, not workspaces. Never add:
 
 - Progress tracking sections ("Next Steps", "TODO", checklists)
@@ -26,6 +28,7 @@ All code and queries in documents must be verified before inclusion.
 
 - SQL: Validate syntax with `bq query --dry_run`, execute to confirm, and include actual results
 - Code: Include only in executable state
+- When editing content within code blocks, verify correctness by executing the code. This applies to every edit regardless of size — including renames, constant changes, and incremental modifications
 - Never fabricate data
 
 ## Data-Driven

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This repository's `.claude/` directory contains the **source files** for Claude 
 - `.claude/skills/` - User-level skills
 
 **When editing Claude configuration files:**
+
 - ALWAYS modify files in `<repository-root>/.claude/` directory
 - These are version-controlled source files
 - Changes should be committed to git
@@ -36,6 +37,7 @@ This repository's `.claude/` directory contains the **source files** for Claude 
 ✓ **CORRECT:** Editing `.claude/CLAUDE.md` or `.claude/rules/*.md` in this repository
 
 When asked to modify Claude configuration:
+
 - Edit `.claude/CLAUDE.md` (NOT `~/.claude/CLAUDE.md`)
 - Edit `.claude/rules/*.md` (NOT `~/.claude/rules/*.md`)
 - Edit `.claude/skills/*/` (NOT `~/.claude/skills/*/`)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Personal dotfiles for managing development environment configurations.
 ### Claude Code Configuration
 
 - **CLAUDE.md** - Professional engineering principles
+- **rules/** - Always-on rules applied across all conversations
 - **skills/** - Specialized capabilities for specific tasks
 
 ### mise Configuration
@@ -26,6 +27,7 @@ cd ~/dotfiles
 ```text
 ~/.claude/
 ├── CLAUDE.md
+├── rules/
 └── skills/
 
 ~/.config/mise/
@@ -62,21 +64,25 @@ npx skills add yusuke-suzuki/dotfiles --all -g
 ### By Workflow
 
 **Analysis Workflow**
+
 ```bash
 npx skills add yusuke-suzuki/dotfiles -g -s "bq-studio analysis-report"
 ```
 
 **Looker Studio Workflow**
+
 ```bash
 npx skills add yusuke-suzuki/dotfiles -g -s "bq-studio looker-studio-report"
 ```
 
 **Technical Writing Workflow**
+
 ```bash
 npx skills add yusuke-suzuki/dotfiles -g -s "technical-writing"
 ```
 
 **Git Workflow**
+
 ```bash
 npx skills add yusuke-suzuki/dotfiles -g -s "commit fixup publish sync resolve-comments"
 ```

--- a/install.sh
+++ b/install.sh
@@ -3,13 +3,14 @@ set -e
 
 # Dotfiles Installer
 # This script installs:
-#   - Claude Code skills and CLAUDE.md
+#   - Claude Code CLAUDE.md, rules, and skills
 #   - mise configuration
 # Run this script from the cloned repository directory
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$SCRIPT_DIR/.claude"
 CLAUDE_DIR="$HOME/.claude"
+RULES_DIR="$CLAUDE_DIR/rules"
 SKILLS_DIR="$CLAUDE_DIR/skills"
 MISE_CONFIG_DIR="$HOME/.config/mise"
 
@@ -25,12 +26,21 @@ fi
 
 # Clean and recreate directories
 echo "🧹 Cleaning existing configurations..."
-rm -rf "$SKILLS_DIR"
-mkdir -p "$SKILLS_DIR"
+rm -rf "$RULES_DIR" "$SKILLS_DIR"
+mkdir -p "$RULES_DIR" "$SKILLS_DIR"
 
 # Install CLAUDE.md
 echo "📝 Installing CLAUDE.md..."
 cp "$SOURCE_DIR/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md"
+
+# Install rules
+echo "📏 Installing rules..."
+for rule_file in "$SOURCE_DIR"/rules/*.md; do
+    if [ -f "$rule_file" ]; then
+        echo "   Installing rule: $(basename "$rule_file")"
+        cp "$rule_file" "$RULES_DIR"
+    fi
+done
 
 # Install skills
 echo ""
@@ -74,6 +84,11 @@ echo "Installation complete!"
 echo ""
 echo "Installed files:"
 echo "  - $CLAUDE_DIR/CLAUDE.md"
+for rule_file in "$RULES_DIR"/*.md; do
+    if [ -f "$rule_file" ]; then
+        echo "  - $rule_file"
+    fi
+done
 for skill_dir in "$SKILLS_DIR"/*/; do
     if [ -d "$skill_dir" ]; then
         echo "  - $skill_dir"


### PR DESCRIPTION
## Summary

Add `.claude/rules/` for text formatting and writing style rules that are automatically loaded into every conversation context, complementing the portable lint-doc skill rules.

## Motivation

Lint-doc skill rules only apply when `/lint-doc` is explicitly invoked. This means PR descriptions, commit messages, and issue comments are written without style rules. By placing essential rules in `.claude/rules/`, they are always loaded as context regardless of skill invocation.

## Changes

- Add `.claude/rules/text-formatting-ja.md` and `.claude/rules/writing-style.md` as always-on rules
- Move code block verification rule from `CLAUDE.md` Safety to `document-writing.md` Content Verification
- Add self-contained document rule (no local file links) to `document-writing.md`
- Update `install.sh` to deploy rules directory
- Update `README.md` and `CLAUDE.md` to reflect new structure

## Testing

- [x] `bash -n install.sh` syntax check passed
- [x] Verified rule files are correctly placed

## Checklist

- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)