### PR TITLE
docs: add git log style guide warning to commit skill

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -59,4 +59,5 @@ This addresses the security requirements in issue #123.
 
 - NEVER commit directly to master/main
 - NEVER use `git commit --fixup` or `git commit --amend` (use `/fixup` command instead)
+- NEVER reference `git log` messages as a style guide for commit messages, as past messages may not follow the correct format.
 - This command creates a NEW, INDEPENDENT commit only


### PR DESCRIPTION
## Summary

Add a constraint to the commit skill that prevents referencing `git log` messages as a style guide for commit messages.

## Motivation

Past commit messages may not follow the Conventional Commits format. Using them as a formatting reference can lead to inconsistent or incorrect commit messages. This rule ensures the skill always follows its own specified format.

## Changes

- Add "NEVER reference `git log` messages as a style guide" constraint to commit skill

## Testing

- [x] Manual testing completed

## Checklist

- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)