### PR TITLE
refactor: split skill installation into core and additional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This repository's `.claude/` directory contains the **source files** for Claude 
 
 - `.claude/CLAUDE.md` - User-level configuration (deployed to all projects)
 - `.claude/rules/` - User-level rules
-- `.claude/skills/` - User-level skills
+- `.claude/skills/` - User-level skills (core skills deployed by `install.sh`, others via `npx skills`)
 
 **When editing Claude configuration files:**
 
@@ -26,10 +26,24 @@ This repository's `.claude/` directory contains the **source files** for Claude 
 
 ### Deployment Workflow
 
+**CLAUDE.md and rules** (via `install.sh`):
+
 1. Edit source files in `.claude/` directory
 2. Commit changes to git
 3. Run `install.sh` to deploy changes to `~/.claude/`
 4. Changes become active across all projects on the machine
+
+**Core skills** (via `install.sh`):
+
+- Core skills (commit, fixup, publish, sync, resolve-comments, lint-doc) are deployed by `install.sh`
+- Defined in the `CORE_SKILLS` array in `install.sh`
+
+**Additional skills** (via `npx skills`):
+
+1. Edit skill files in `.claude/skills/` directory
+2. Commit and push changes to git
+3. Run `npx skills add yusuke-suzuki/dotfiles -g -s "skill-name"` to install
+4. Skills become active across all projects on the machine
 
 ## Common Mistake to Avoid
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Personal dotfiles for managing development environment configurations.
 
 - **CLAUDE.md** - Professional engineering principles
 - **rules/** - Always-on rules applied across all conversations
-- **skills/** - Specialized capabilities for specific tasks
+- **skills/** - Specialized capabilities for specific tasks (core skills installed by `install.sh`, others via `npx skills`)
 
 ### mise Configuration
 
@@ -28,7 +28,7 @@ cd ~/dotfiles
 ~/.claude/
 ├── CLAUDE.md
 ├── rules/
-└── skills/
+└── skills/        # Core skills only
 
 ~/.config/mise/
 └── config.toml
@@ -38,7 +38,6 @@ cd ~/dotfiles
 
 - Git
 - GitHub CLI (`gh`)
-- Google Cloud SDK (`bq`)
 - mise
 
 ### Updating
@@ -51,9 +50,9 @@ git pull
 
 Existing files are automatically backed up before installation.
 
-## Installing Skills via npx skills
+## Installing Additional Skills
 
-You can also install individual skills or groups of skills using the Agent Skills ecosystem.
+Core skills are installed automatically by `install.sh`. Additional skills can be installed per environment using the Agent Skills ecosystem.
 
 ### All Skills
 

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,9 @@ set -e
 
 # Dotfiles Installer
 # This script installs:
-#   - Claude Code CLAUDE.md, rules, and skills
+#   - Claude Code CLAUDE.md, rules, and core skills
 #   - mise configuration
+# Additional skills can be installed via `npx skills`
 # Run this script from the cloned repository directory
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,6 +14,9 @@ CLAUDE_DIR="$HOME/.claude"
 RULES_DIR="$CLAUDE_DIR/rules"
 SKILLS_DIR="$CLAUDE_DIR/skills"
 MISE_CONFIG_DIR="$HOME/.config/mise"
+
+# Core skills installed by default
+CORE_SKILLS=(commit fixup publish sync resolve-comments lint-doc)
 
 echo "Installing dotfiles..."
 echo ""
@@ -24,10 +28,10 @@ if [ ! -d "$SOURCE_DIR" ]; then
     exit 1
 fi
 
-# Clean and recreate directories
-echo "🧹 Cleaning existing configurations..."
-rm -rf "$RULES_DIR" "$SKILLS_DIR"
-mkdir -p "$RULES_DIR" "$SKILLS_DIR"
+# Clean and recreate rules directory
+echo "🧹 Cleaning existing rules..."
+rm -rf "$RULES_DIR"
+mkdir -p "$RULES_DIR"
 
 # Install CLAUDE.md
 echo "📝 Installing CLAUDE.md..."
@@ -42,15 +46,18 @@ for rule_file in "$SOURCE_DIR"/rules/*.md; do
     fi
 done
 
-# Install skills
+# Install core skills
 echo ""
-echo "📚 Installing skills..."
-for skill_dir in "$SOURCE_DIR"/skills/*/; do
+echo "🔧 Installing core skills..."
+mkdir -p "$SKILLS_DIR"
+for skill_name in "${CORE_SKILLS[@]}"; do
+    skill_dir="$SOURCE_DIR/skills/$skill_name"
     if [ -d "$skill_dir" ]; then
-        skill_name=$(basename "$skill_dir")
-        dest_dir="$SKILLS_DIR/$skill_name"
         echo "   Installing skill: $skill_name"
-        cp -r "$skill_dir" "$dest_dir"
+        rm -rf "$SKILLS_DIR/$skill_name"
+        cp -r "$skill_dir" "$SKILLS_DIR/$skill_name"
+    else
+        echo "   ⚠️  Skill not found: $skill_name"
     fi
 done
 
@@ -89,29 +96,20 @@ for rule_file in "$RULES_DIR"/*.md; do
         echo "  - $rule_file"
     fi
 done
-for skill_dir in "$SKILLS_DIR"/*/; do
-    if [ -d "$skill_dir" ]; then
-        echo "  - $skill_dir"
+for skill_name in "${CORE_SKILLS[@]}"; do
+    if [ -d "$SKILLS_DIR/$skill_name" ]; then
+        echo "  - $SKILLS_DIR/$skill_name/"
     fi
 done
 if [ "$MISE_INSTALLED" = true ]; then
     echo "  - $MISE_CONFIG_DIR/config.toml"
 fi
-echo ""
-echo "Claude Code skills:"
-for skill_dir in "$SKILLS_DIR"/*/; do
-    if [ -d "$skill_dir" ]; then
-        skill_name=$(basename "$skill_dir")
-        skill_file="$skill_dir/SKILL.md"
-        if [ -f "$skill_file" ]; then
-            description=$(grep -m1 "^description:" "$skill_file" | sed 's/^description:[[:space:]]*//')
-            printf "  %-18s - %s\n" "$skill_name" "$description"
-        fi
-    fi
-done
 if [ "$MISE_INSTALLED" = true ]; then
     echo ""
     echo "mise setup:"
     echo "  Add the following to your shell config (e.g., ~/.bashrc, ~/.zshrc):"
     echo '    eval "$(mise activate)"'
 fi
+echo ""
+echo "To install additional skills:"
+echo "  npx skills add yusuke-suzuki/dotfiles --all -g"


### PR DESCRIPTION
## Summary

Split skill installation into two tiers: core skills deployed automatically by `install.sh`, and additional skills installed on-demand via `npx skills`.

## Motivation

Analysis-related skills (bq-studio, looker-studio-report, analysis-report) can overlap with work-provided skills. By making them opt-in per environment, duplication is avoided while core skills (git workflow, lint-doc) remain always available.

## Changes

- `install.sh` now installs only `CORE_SKILLS` array members (commit, fixup, publish, sync, resolve-comments, lint-doc) instead of all skills
- Removed `rm -rf ~/.claude/skills/` so `npx skills`-installed skills survive `install.sh` re-runs
- Updated CLAUDE.md deployment workflow documentation
- Updated README to reflect the two-tier installation model

## Testing

- [ ] Run `install.sh` and verify only core skills are installed
- [ ] Run `npx skills add yusuke-suzuki/dotfiles --all -g` and verify additional skills are installed
- [ ] Re-run `install.sh` and verify `npx skills`-installed skills are preserved

## Checklist

- [x] Follows style guidelines
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)