### PR TITLE
refactor: extract commit message rules from skill

### DIFF
--- a/.claude/rules/commit-message.md
+++ b/.claude/rules/commit-message.md
@@ -1,0 +1,47 @@
+# Commit Message Conventions
+
+Apply when creating git commits.
+
+## Format
+
+- Conventional Commits format
+- English, imperative mood, present tense
+- Example: `feat: add user authentication` (not `added`)
+
+## Subject Line
+
+- Maximum 50 characters (including prefix and scope)
+- Verify: `echo -n "subject" | wc -c`
+
+## Body
+
+- Blank line after subject
+- Start each sentence on a new line
+- Wrap at 72 characters
+- Add blank lines between paragraphs for readability
+- Explain the rationale for the change (the "why"),
+  not just what was modified or how it was implemented
+
+### Examples
+
+**Bad** - describes what changed, sentences not separated by newlines:
+```
+refactor: reorganize auth module
+
+Remove legacy login handler. Move token refresh logic to middleware. Update error codes to use standard format.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+**Good** - explains why, each sentence on a new line, blank lines between paragraphs:
+```
+refactor: reorganize auth module
+
+The legacy login handler duplicated logic already
+covered by the OAuth flow introduced in v2.
+
+Moving token refresh into middleware reduces repeated
+try/catch blocks across six route handlers.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -27,33 +27,8 @@ You are assisting with creating a git commit. Follow these steps:
 ## 3. Commit Creation
 
 - Stage changes with `git add .` or ask user which files to stage
-- Craft a commit message using Conventional Commits format (see below)
+- Craft a commit message
 - Execute `git commit`
-
-### Commit Message Format
-
-**Structure:**
-```
-<type>: <description>
-
-[optional body]
-```
-
-**Requirements:**
-- Type: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, etc.
-- Description: imperative mood, present tense (e.g., "add" not "added")
-- Subject line: maximum 50 characters (including type and scope)
-- Body: one sentence per line, wrap at 72 characters, explain the "why" not the "what"
-- Blank line between subject and body, and between logical paragraphs
-
-**Example:**
-```
-feat: add user authentication
-
-Implement JWT-based authentication to secure API endpoints.
-
-This addresses the security requirements in issue #123.
-```
 
 ## Key Constraints
 


### PR DESCRIPTION
## Summary

Commit message format rules were embedded inside the `/commit` skill workflow, causing them to be overlooked during commit creation.
This restores them as a standalone rules file so they are always loaded into context.

## Motivation

In yusuke-suzuki/dotfiles#41, `commit-message.md` was merged into the skill to make it self-contained.
However, rules buried in a skill's workflow steps were repeatedly not followed (e.g., "start each sentence on a new line" and "why not what" violations).

A standalone rules file is always visible regardless of which skill is active.

## Changes

- Add `.claude/rules/commit-message.md` with the original rules plus "start each sentence on a new line" and good/bad examples
- Remove the duplicated "Commit Message Format" section from the `/commit` skill

## Testing

- [ ] Manual testing completed

## Checklist

- [x] Follows style guidelines
- [ ] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)