### PR TITLE
fix(skills): apply review feedback to release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -15,14 +15,18 @@ Get the latest semver tag:
 git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1
 ```
 
-If no tags exist, treat the current version as `v0.1.0` and skip to step 3.
+If no tags exist, treat the current version as `v0.1.0`, proceed to step 2 using all commits, then skip to step 3.
 
 ## 2. Changes Since Last Release
 
-List commits with full messages since the latest tag:
+List commits with full messages since the latest tag (or all commits if no tags exist):
 
 ```bash
+# If a tag exists:
 git log <latest-tag>..HEAD --format="%h %s%n%b"
+
+# If no tags exist:
+git log HEAD --format="%h %s%n%b"
 ```
 
 Read the commit subjects and bodies to understand the nature of each change.
@@ -92,5 +96,5 @@ gh release edit <next-tag> --draft=false
 ## 7. Final Output
 
 - Pushed tag: `<next-tag>`
-- GitHub Actions: show run URL from `gh run list --branch <next-tag>`
+- GitHub Actions: show run URL from `gh run list --branch <next-tag> --limit 1 --json url --template '{{range .}}{{.url}}{{end}}'`
 - GitHub release: show URL from `gh release view <next-tag> --json url -q .url`


### PR DESCRIPTION
# Summary

Applies two fixes to the release skill based on review comments from #55.

# Motivation

The initial version skipped step 2 (commit history review) when no tags existed, and used a plain `gh run list` that returns a table rather than a URL.

# Changes

- Step 2 now handles the no-tag case by running `git log HEAD` so the agent reviews all commits for the initial release
- Step 7 uses `--json url` with a template to extract the GitHub Actions run URL explicitly

🤖 Generated with [Claude Code](https://claude.ai/code)