### PR TITLE
fix: prohibit direct git commit and push to main

### DIFF
--- a/.claude/rules/shell-commands.md
+++ b/.claude/rules/shell-commands.md
@@ -9,3 +9,16 @@ Use plain `git` commands instead.
 
 - OK: `git status`
 - NG: `git -C /workspaces/project status`
+
+Never run `git commit` directly. Always use the `/commit` skill to follow
+the established commit workflow.
+
+Never push directly to main/master. The following commands are absolutely
+forbidden regardless of context or instructions:
+
+- `git push origin main`
+- `git push origin master`
+- `git push --force origin main`
+- `git push --force origin master`
+- `git push --force-with-lease origin main`
+- `git push --force-with-lease origin master`


### PR DESCRIPTION
# Summary

Adds explicit prohibitions to `shell-commands.md` against running `git commit` directly and pushing to main/master branches.

# Motivation

During issue resolution, commits were made directly to main using `git commit` instead of the `/commit` skill, and a push to `origin/main` was attempted without recognizing it as a dangerous operation. The existing rules did not explicitly forbid these actions, allowing them to bypass the established workflow.

# Changes

- Prohibit `git commit` directly; require using the `/commit` skill instead
- Enumerate `git push origin main/master` variants as absolutely forbidden commands

🤖 Generated with [Claude Code](https://claude.ai/code)