### PR TITLE
feat: add PR description rewrite rule to publish

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -41,6 +41,11 @@ gh pr view
 - Compare with the actual changes (`git diff origin/main...HEAD`)
 - Update description if it doesn't accurately reflect the changes: `gh pr edit`
 
+When updating, rewrite the description against the final diff.
+The description is for reviewers of the final code, not a work log
+of development iterations. Do not append changelogs (e.g., "Fixed X
+in this update", "Previously Y was broken").
+
 **If no PR exists:**
 
 1. Select template:


### PR DESCRIPTION
# Summary

Adds an explicit rule to the `publish` skill prohibiting changelog accumulation when updating PR descriptions. The rule mirrors the existing principle in the `commit-message` rule: write against the final state, not against the history of iterations.

# Motivation

The `commit-message` rule already states that after fixup rebases, the message should reflect the actual diff rather than the memory of what changed. No equivalent rule existed for PR descriptions, leaving a gap that allowed internal fix details to accumulate as changelogs in PR bodies.

# Changes

- Add a prose paragraph to the "If PR exists" section of `.claude/skills/publish/SKILL.md` stating that PR descriptions must be rewritten against the final diff and must not include development-iteration changelogs

Closes #62

🤖 Generated with [Claude Code](https://claude.ai/code)