### PR TITLE
feat: strengthen rules and commit guidance

### DIFF
--- a/.claude/rules/commit-message.md
+++ b/.claude/rules/commit-message.md
@@ -21,6 +21,10 @@ Apply when creating git commits.
 - Add blank lines between paragraphs for readability
 - Explain the rationale for the change (the "why"),
   not just what was modified or how it was implemented
+- When a commit includes supporting changes (refactoring, cleanup)
+  alongside the main feature, focus the body on the core motivation.
+  Do not enumerate supporting changes individually unless their
+  rationale is non-obvious and independent.
 
 ## Closing Issues
 

--- a/.claude/rules/document-writing.md
+++ b/.claude/rules/document-writing.md
@@ -22,6 +22,14 @@ Documents are deliverables, not workspaces. Never add:
 
 Use the TodoWrite tool for task management instead.
 
+## Templates
+
+When a template is provided (PR templates, issue templates, etc.),
+preserve its structure and formatting. Do not remove sections,
+reorder items, or alter formatting (strikethrough, checkboxes, HTML
+comments, etc.). Fill in the provided sections; add new sections
+only if the template explicitly allows it.
+
 ## Progressive Disclosure
 
 - Explain concepts before details

--- a/.claude/rules/shell-commands.md
+++ b/.claude/rules/shell-commands.md
@@ -13,6 +13,9 @@ Use plain `git` commands instead.
 Never run `git commit` directly. Always use the `/commit` skill to follow
 the established commit workflow.
 
+Never run `git push` directly. Always use the `/publish` skill so
+that the PR description is kept in sync with the current diff.
+
 Never push directly to main/master. The following commands are absolutely
 forbidden regardless of context or instructions:
 

--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -30,6 +30,14 @@ When editing existing text, match the established style:
 - **Japanese**: Match formality (です/ます vs である/だ). Never mix within the same context.
 - **English**: Match tone and voice (formal, casual, technical).
 
+## Redundancy
+
+Do not explain what is self-evident from context:
+
+- Project conventions obvious from the codebase (e.g., deploy mechanisms, framework behavior)
+- Information the reader already stated or demonstrated knowledge of
+- Implementation details that the code itself makes clear
+
 ## Signature
 
 When generating documents, PR descriptions, or other published content, always end with:

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -27,6 +27,10 @@ You are assisting with creating a git commit. Follow these steps:
 
 ## 3. Commit Creation
 
+- When writing the message body, explain WHY the change is needed.
+  Do not list every file or sub-change — the diff shows that.
+  Focus on the core motivation; omit supporting changes unless
+  they have independent rationale a reviewer needs to understand.
 - Analyze the uncommitted changes and group them by semantic intent
 - If changes fall into multiple distinct groups, create one commit per group
 - For each group: `git add <files>`, craft a commit message, then `git commit`


### PR DESCRIPTION
# Summary

Add explicit rules and guidance that were previously implicit, addressing three recurring issues observed in sessions.

# Motivation

Direct `git push` bypassed the `/publish` skill, leaving PR descriptions out of sync. Commit messages for mixed-intent changes over-enumerated sub-changes. Template formatting was altered without constraint, and redundant explanations of project-obvious information added noise.

# Changes

- Require `/publish` skill for `git push` in `shell-commands.md`
- Add mixed-intent commit body guidance to `commit-message.md` and `skills/commit/SKILL.md`
- Add template preservation rule to `document-writing.md`
- Add redundancy avoidance rule to `writing-style.md`

<!-- Add additional sections below as needed (e.g., Testing, Checklist) -->

fixes #68
fixes #69
fixes #70

🤖 Generated with [Claude Code](https://claude.ai/code)