### PR TITLE
feat: add commit types and diff analysis step

### DIFF
--- a/.claude/rules/commit-message.md
+++ b/.claude/rules/commit-message.md
@@ -8,6 +8,42 @@ Apply when creating git commits.
 - English, imperative mood, present tense
 - Example: `feat: add user authentication` (not `added`)
 
+## Types
+
+| Type       | Changelog Section        |
+| ---------- | ------------------------ |
+| `feat`     | Features                 |
+| `fix`      | Bug Fixes                |
+| `perf`     | Performance Improvements |
+| `deps`     | Dependencies             |
+| `revert`   | Reverts                  |
+| `docs`     | Documentation            |
+| `style`    | Styles                   |
+| `chore`    | Miscellaneous Chores     |
+| `refactor` | Code Refactoring         |
+| `test`     | Tests                    |
+| `build`    | Build System             |
+| `ci`       | Continuous Integration   |
+
+Based on release-please `DEFAULT_HEADINGS`. Types not listed here
+will not appear in the generated changelog.
+
+## Breaking Changes
+
+Mark breaking changes with `!` after the type/scope:
+
+```
+feat!: remove deprecated endpoint
+```
+
+For detailed explanation, add a `BREAKING CHANGE` footer:
+
+```
+feat: allow config to extend other configs
+
+BREAKING CHANGE: `extends` key behavior changed
+```
+
 ## Subject Line
 
 - Maximum 50 characters (including prefix and scope)

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -25,13 +25,21 @@ You are assisting with creating a git commit. Follow these steps:
 - Display the current branch name
 - Show existing commits relative to main
 
-## 3. Commit Creation
+## 3. Diff Analysis
 
+Understand the changes before staging:
+
+- Review staged changes: `git diff --staged`
+- Review unstaged changes: `git diff`
+- Group changes by semantic intent (one logical change per commit)
+
+## 4. Commit Creation
+
+- Never stage files that contain secrets (.env, credentials, private keys)
 - When writing the message body, explain WHY the change is needed.
   Do not list every file or sub-change — the diff shows that.
   Focus on the core motivation; omit supporting changes unless
   they have independent rationale a reviewer needs to understand.
-- Analyze the uncommitted changes and group them by semantic intent
 - If changes fall into multiple distinct groups, create one commit per group
 - For each group: `git add <files>`, craft a commit message, then `git commit`
 


### PR DESCRIPTION
# Summary

Add an explicit commit type reference table and a dedicated diff analysis step to the commit workflow.

# Motivation

The commit rules had no enumeration of valid types, making it possible to use types that release-please does not recognize for changelog generation. The commit skill also combined diff analysis and staging into a single implicit step, omitting guidance on staged vs unstaged handling.

Inspired by [github/awesome-copilot git-commit skill](https://github.com/github/awesome-copilot/blob/main/skills/git-commit/SKILL.md).

# Changes

- Add Types section to commit-message rules based on release-please `DEFAULT_HEADINGS`
- Add Breaking Changes section covering `!` notation and `BREAKING CHANGE` footer
- Split commit skill step 3 into Diff Analysis (step 3) and Commit Creation (step 4)
- Add secret file staging prohibition to the commit creation step

🤖 Generated with [Claude Code](https://claude.ai/code)