### PR TITLE
feat: deploy settings.json via install.sh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,25 @@
 {
   "permissions": {
     "allow": [
-      "Bash(gh pr view:*)",
-      "Bash(gh pr diff:*)",
-      "Bash(gh pr checks:*)",
-      "Bash(gh run view:*)",
-      "Bash(gh issue view:*)",
+      "Bash(bq ls:*)",
       "Bash(bq show:*)",
-      "Bash(bq ls:*)"
+      "Bash(gh issue view:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh release view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "Bash(git diff:*)",
+      "Bash(git fetch:*)",
+      "Bash(git log:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git show:*)",
+      "Bash(git status:*)",
+      "Bash(git tag --sort:*)"
     ]
   },
+  "language": "japanese",
   "enabledPlugins": {
     "example-skills@anthropic-agent-skills": true
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 This repository's `.claude/` directory contains the **source files** for Claude Code configuration:
 
 - `.claude/CLAUDE.md` - User-level configuration
+- `.claude/settings.json` - User-level settings
 - `.claude/rules/` - User-level rules
 - `.claude/skills/` - User-level skills
 
@@ -48,5 +49,6 @@ This repository's `.claude/` directory contains the **source files** for Claude 
 When asked to modify Claude configuration:
 
 - Edit `.claude/CLAUDE.md` (NOT `~/.claude/CLAUDE.md`)
+- Edit `.claude/settings.json` (NOT `~/.claude/settings.json`)
 - Edit `.claude/rules/*.md` (NOT `~/.claude/rules/*.md`)
 - Edit `.claude/skills/*/` (NOT `~/.claude/skills/*/`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # Dotfiles Installer
 # This script installs:
-#   - Claude Code CLAUDE.md, rules, and skills
+#   - Claude Code CLAUDE.md, settings.json, rules, and skills
 #   - mise configuration
 # Run this script from the cloned repository directory
 
@@ -32,6 +32,10 @@ mkdir -p "$RULES_DIR"
 # Install CLAUDE.md
 echo "📝 Installing CLAUDE.md..."
 cp "$SOURCE_DIR/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md"
+
+# Install settings.json
+echo "⚙️  Installing settings.json..."
+cp "$SOURCE_DIR/settings.json" "$CLAUDE_DIR/settings.json"
 
 # Install rules
 echo "📏 Installing rules..."
@@ -85,6 +89,7 @@ echo "Installation complete!"
 echo ""
 echo "Installed files:"
 echo "  - $CLAUDE_DIR/CLAUDE.md"
+echo "  - $CLAUDE_DIR/settings.json"
 for rule_file in "$RULES_DIR"/*.md; do
     if [ -f "$rule_file" ]; then
         echo "  - $rule_file"


### PR DESCRIPTION
# Summary

Add `settings.json` to the install.sh deployment pipeline and pre-approve read-only git/gh commands used by skills.

# Motivation

`settings.json` was version-controlled but never deployed by `install.sh`, causing the source and deployed copies to diverge silently. Any settings changes made in the repository had no effect until manually copied.

# Changes

- Add `settings.json` copy step to `install.sh`
- Add `language: "japanese"` setting
- Pre-approve read-only `git` and `gh` commands used across skills (commit, fixup, sync, release, publish)
- Update `CLAUDE.md` to document `settings.json` as a managed source file

🤖 Generated with [Claude Code](https://claude.ai/code)