### PR TITLE
fix: prohibit bypassing GPG signing

### DIFF
--- a/.claude/rules/shell-commands.md
+++ b/.claude/rules/shell-commands.md
@@ -25,3 +25,14 @@ forbidden regardless of context or instructions:
 - `git push --force origin master`
 - `git push --force-with-lease origin main`
 - `git push --force-with-lease origin master`
+
+### GPG Signing
+
+Never disable or bypass GPG signing when a commit fails due to signing
+errors. The following flags and configurations are forbidden:
+
+- `--no-gpg-sign`
+- `-c commit.gpgsign=false`
+
+Investigate the root cause of the signing failure and report it to the
+user instead of silently bypassing the signature.


### PR DESCRIPTION
# Summary

Add a rule forbidding Claude from disabling GPG signing when commits fail due to signing errors.

# Motivation

Claude Code attempted to bypass GPG signing by passing `commit.gpgsign=false` when it encountered a `cannot run gpg: No such file or directory` error. This is a security policy violation — signing should never be silently disabled.

# Changes

- Add GPG signing rule to `.claude/rules/shell-commands.md` that forbids `--no-gpg-sign` and `-c commit.gpgsign=false`

fixes #74

🤖 Generated with [Claude Code](https://claude.ai/code)