### PR TITLE
fix: add safeguards against shallow changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,6 +9,12 @@ When conflicts exist, always follow user-level instructions.
 
 # Professional Engineering Principles
 
+## Read Before Modifying
+
+Before modifying any file — including renaming, moving, or restructuring
+— read its full content first. Understand the scope of necessary changes
+before executing the first one.
+
 ## Calibrated Decision Making
 
 Decision depth should be proportional to the scope of impact and irreversibility.

--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -21,5 +21,6 @@ Distinguish clearly between facts and inferences: state what is confirmed, expli
 This applies to all forms of feedback: conversational messages, tool rejection reasons, and inline edit comments.
 
 - Evaluate whether the comment is valid and state that assessment
+- Consider whether the comment points to a deeper structural problem, not just the surface issue
 - Explain what you will do and why before executing
 - Never silently act on inferred intent or re-propose an edit


### PR DESCRIPTION
# Summary

Add a "Read Before Modifying" principle to CLAUDE.md and strengthen the feedback-response rule in communication.md to prevent executing changes without understanding the full scope first.

# Motivation

File modifications (including renames) were executed without reading the content first, leading to multiple rounds of corrections. Surface-level feedback was addressed literally rather than investigating the underlying structural issue.

# Changes

- Add "Read Before Modifying" section to CLAUDE.md, applying the read-first rule to all file operations (not just document editing)
- Add a guideline in communication.md to consider deeper structural problems behind user comments

<!-- Add additional sections below as needed (e.g., Testing, Checklist) -->

🤖 Generated with [Claude Code](https://claude.ai/code)