### PR TITLE
fix: guard against commit message language drift

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -85,3 +85,15 @@ project-specific details that could expose private context:
 - Any personally identifiable information
 
 Use generic descriptions that convey intent without leaking private context.
+
+## Memory Boundaries
+
+When a correction or insight points to durable behavioral guidance
+(not project- or user-specific context), the fix belongs in a rules
+file or CLAUDE.md — not in a memory entry.
+
+Do not save to memory:
+
+- Content that restates or paraphrases an existing rule
+- Behavioral guidance that should apply across all projects
+  (this belongs in `~/.claude/rules/` or `~/.claude/CLAUDE.md`)

--- a/.claude/rules/commit-message.md
+++ b/.claude/rules/commit-message.md
@@ -6,6 +6,7 @@ Apply when creating git commits.
 
 - Conventional Commits format
 - English, imperative mood, present tense
+- Always write in English regardless of the language of the changed files
 - Example: `feat: add user authentication` (not `added`)
 
 ## Types

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -45,10 +45,16 @@ Understand the changes before staging:
 ## 4. Commit Creation
 
 - Never stage files that contain secrets (.env, credentials, private keys)
-- **Verify subject length before committing:**
-  Run `echo -n "<subject>" | wc -m` and confirm the result is ≤ 50.
-  If it exceeds 50, shorten the subject and re-verify. Do not proceed
-  with `git commit` until the check passes.
+- **Verify the drafted commit message against all rules in
+  `~/.claude/rules/commit-message.md` before running `git commit`.**
+  Check at minimum:
+  - Subject line is ≤ 50 characters
+    (run `echo -n "<subject>" | wc -m` to confirm)
+  - Subject and body are written in English
+  - Format follows Conventional Commits
+  - Body explains the rationale, not the mechanics
+  If any check fails, fix the message and re-verify. Do not proceed
+  with `git commit` until all checks pass.
 - When writing the message body, explain WHY the change is needed.
   Do not list every file or sub-change — the diff shows that.
   Focus on the core motivation; omit supporting changes unless


### PR DESCRIPTION
# Summary

Add guardrails to prevent commit message language drift when committing changes to non-English files, and prevent redundant memory saves that duplicate existing rules.

# Motivation

When committing changes to Japanese files, the surrounding language context caused the commit message body to drift into Japanese, violating the English-only rule. After correction, a reactive memory save duplicated content already covered by `commit-message.md`. Both failures stem from the same root cause: file content language influencing subsequent actions.

# Changes

- Explicit English-language requirement in `commit-message.md` regardless of changed file language
- Comprehensive pre-commit rule-compliance check in the commit skill (replacing subject-length-only check)
- Memory boundary rule in `CLAUDE.md` to prevent saving content that belongs in rules files

fixes #99

🤖 Generated with [Claude Code](https://claude.ai/code)