### PR TITLE
refactor: clarify rule scope and coverage

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -68,6 +68,19 @@ Decision depth should be proportional to the scope of impact and irreversibility
 - ❌ "Which approach is better?"
 - ❌ "Is this okay?"
 
+## Prefer Standards
+
+Use the standard workflow provided by the framework or language before
+reaching for alternatives.
+
+1. Use generators, CLI tools, and built-in APIs that the technology
+   provides (e.g., `rails generate`, `npm init`, `mix phx.gen`)
+2. Before adopting third-party libraries or custom solutions, verify
+   that standard technology cannot meet the requirement
+3. Do not use Write, Edit, or similar tools to create files that a
+   generator would produce — generators set up boilerplate, naming
+   conventions, and registration that manual creation can miss
+
 ## Safety
 
 - Never modify production data for testing purposes

--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -1,6 +1,9 @@
 # Communication
 
-Apply to all conversational interactions.
+Apply to all interactive text: conversations, PR descriptions, issue
+comments, and review replies. Documents (design docs, READMEs) follow
+`writing-style.md` / `document-writing.md` Style Consistency rules
+instead — match the document's existing style.
 
 ## Tone
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: Create a git commit with Conventional Commits format
+description: Create a git commit with Conventional Commits format. Invoke as soon as changes are ready — branch creation, staging, and message authoring are all part of this workflow.
 ---
 
 # Commit


### PR DESCRIPTION
# Summary

Clarify ambiguous or missing rule scope that caused repeated violations across sessions.

# Motivation

A retro identified three rule gaps: framework standard workflows bypassed with Write/Edit tools, keigo not applied to PR descriptions, and manual branch creation before the /commit skill.

# Changes

- Add "Prefer Standards" section to CLAUDE.md requiring framework generators and CLIs over manual file creation
- Expand communication.md scope from "conversational interactions" to all interactive text (PR descriptions, issue comments, review replies), with explicit carve-out for documents
- Add trigger timing to the commit skill's frontmatter description

🤖 Generated with [Claude Code](https://claude.ai/code)