### PR TITLE
fix: add deliberation and feedback-handling rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,6 +37,15 @@ Decision depth should be proportional to the scope of impact and irreversibility
 - Following established patterns
 - Explicit user instructions
 
+### Before acting on an alternative
+
+Listing options is not deliberation. Before reverting, modifying
+existing work, or otherwise acting on an alternative, enumerate the
+constraints and side effects of each candidate and check them against
+the current state. Skipping this step produces "jump from shallow
+comparison to action" — the very failure mode that deliberation is
+meant to prevent.
+
 ## Professional Ownership
 
 - Think through and propose solutions - don't ask the user to decide for you.

--- a/.claude/rules/feedback-handling.md
+++ b/.claude/rules/feedback-handling.md
@@ -1,0 +1,29 @@
+# Feedback Handling
+
+Apply when responding to real-time user feedback about your own
+behavior or prior actions.
+
+## Do not update memory or rules on the spot
+
+When the user gives behavioral feedback during a session, do not write
+to memory or rule files immediately. Defer durable behavioral guidance
+to the `/retro` workflow at session end.
+
+Self-initiated writes mid-session conflict with the user's retrospective
+process: the retro is the stage where violations, root causes, and
+countermeasures are structured together, and skipping ahead to a
+memory write fragments that analysis.
+
+One-off factual memories the user explicitly asks to save (e.g. "remember
+that the Grafana dashboard is at X") fall outside this rule — it
+targets behavioral corrections, not factual capture.
+
+## Verify before explaining your own actions
+
+When asked about the cause of your own prior action ("why did you do
+X?"), do not answer from reconstruction or guesswork. Verify against
+the actual record — tool call history, referenced context, file state
+— before responding.
+
+If verification is not possible in the current context, say so
+explicitly rather than offering a plausible-sounding guess.


### PR DESCRIPTION
# Summary

Close two rule gaps flagged by retro #104 — one in Calibrated Decision Making and one in how behavioral feedback is handled mid-session.

# Motivation

The retro identified a pattern of acting on alternatives without evaluating their constraints, and a pattern of writing memory or guessing causes mid-session when the user gives behavioral feedback. Both sit in gaps where existing rules covered the spirit but not the specific failure mode, so the violations repeated.

# Changes

- `CLAUDE.md` Calibrated Decision Making: add a "Before acting on an alternative" subsection that names the constraint-enumeration step.
- `rules/feedback-handling.md` (new): defer behavioral updates to `/retro` instead of writing memory mid-session, and verify against tool-call history before explaining own prior actions.

fixes #104

🤖 Generated with [Claude Code](https://claude.ai/code)