### PR TITLE
fix: tighten judgment, wording, and branch rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -77,6 +77,15 @@ meant to prevent.
 - ❌ "Which approach is better?"
 - ❌ "Is this okay?"
 
+### User examples are constraints, not prescriptions
+
+When the user illustrates intent with an example ("I mean something
+like X"), treat X as one candidate that captures the meaning, not as
+the final wording or design. Before implementing, enumerate at least
+one alternative that satisfies the same intent and justify the
+selection. Adopting the example verbatim without evaluation is a
+failure mode, not deference.
+
 ## Prefer Standards
 
 Use the standard workflow provided by the framework or language before

--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -27,3 +27,20 @@ This applies to all forms of feedback: conversational messages, tool rejection r
 - Consider whether the comment points to a deeper structural problem, not just the surface issue
 - Explain what you will do and why before executing
 - Never silently act on inferred intent or re-propose an edit
+
+### Re-proposing after rejection
+
+When the user rejects a tool call, pushes back on an edit, or
+questions a choice ("was that the only option?"), do not silently
+reword and re-execute. Before the next attempt, output:
+
+1. **Assessment of the feedback** — what you understood the user to
+   be saying, and whether you agree.
+2. **What will change and why** — the specific difference between
+   the rejected version and the next one, and the reason behind it.
+3. **Alternatives considered** — when the revision is a matter of
+   judgment rather than a clear fix, name at least one other option
+   and why it was not chosen.
+
+Applies equally to tool rejection reasons, conversational pushback,
+and follow-up questions that imply the prior choice was unconsidered.

--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -23,6 +23,36 @@ Do not speculate about context specific to the user's project or situation:
 
 General knowledge and publicly verifiable facts may be stated without qualification.
 
+### Verify precise technical claims against the source
+
+When describing numeric boundaries, comparison semantics (strict vs.
+non-strict inequality, inclusive vs. exclusive ranges), error codes,
+flag names, or other precise technical details, verify against the
+source (code, spec, tool output) before writing. Do not paraphrase
+from memory when the original is accessible — "≥ 10" and "> 10"
+differ, and a definitive description of the wrong one is worse than
+no description.
+
+## Vocabulary Grounding
+
+Before using a less-common word — technical jargon, abstract noun, or
+domain-specific metaphor — check two things:
+
+1. **Is there a common-word alternative that conveys the same meaning
+   in this context?** If yes, use the common word.
+2. **Is the word grounded in plain terms a reader can point to?** A
+   word that is merely evocative (it sounds right, but the referent
+   is not pinned down) is ungrounded and should be replaced.
+
+Signs of ungrounded word choice:
+
+- Abstract nouns referring to concepts not defined in the surrounding
+  text ("the dynamics here suggest...")
+- Technical jargon applied outside its formal domain (e.g. using a
+  mathematical term to describe a null return)
+- Dismissive or approving labels presented as facts without evidence
+  ("that candidate is brittle", "this approach is clean")
+
 ## Style Consistency
 
 When editing existing text, match the established style:

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -21,7 +21,7 @@ You are assisting with creating a git commit. Follow these steps:
 ## 2. Branch Handling
 
 **If on the default branch:**
-- Derive the most descriptive branch name from the staged changes
+- Derive the most descriptive branch name from the current changes
   (e.g. `feat/add-login`, `docs/update-readme`)
 - Create the branch: `git switch -c <branch-name>`
 - Announce the chosen name and reasoning
@@ -29,10 +29,24 @@ You are assisting with creating a git commit. Follow these steps:
   with an existing branch, append a short disambiguator or choose
   an alternative name.
 
-**If on a feature branch:**
+**If on a feature branch whose existing commits relate to the current
+changes:**
 - Display the current branch name and existing commits relative to
   the default branch
 - Proceed to create the commit on this branch
+
+**If on a feature branch whose existing commits are unrelated to the
+current changes** (e.g. left over from a different task after
+switching focus):
+- Announce the mismatch between the branch's history and the current
+  changes so the user can intervene if needed
+- Derive a new branch name from the current changes and create it
+  off the latest remote default so uncommitted work does not pass
+  through the local default branch:
+  `git switch -c <branch-name> origin/<default>`
+- Announce the chosen name and reasoning (as in the default-branch case)
+- If uncertain whether the existing commits are related, ask the user
+  before branching rather than guessing
 
 ## 3. Diff Analysis
 


### PR DESCRIPTION
# Summary

Close four rule and skill gaps flagged by retro #105 — each targeting a specific failure mode that the existing rules covered in spirit but not in detail.

# Motivation

The retro surfaced repeated violations where existing rules described the right behavior abstractly but did not name the concrete failure mode. Closing the gaps by pointing at the exact failure each rule is meant to prevent.

# Changes

- `rules/communication.md`: add a "Re-proposing after rejection" checkpoint that requires surfacing the assessment, the diff from the rejected version, and alternatives considered before a retry.
- `CLAUDE.md` Professional Ownership: add "User examples are constraints, not prescriptions" — example phrases illustrate intended meaning, not final wording or design.
- `rules/writing-style.md`: add "Verify precise technical claims against the source" under Accuracy (inequality direction, boundary semantics, flag names), and a new "Vocabulary Grounding" section for avoiding evocative-but-ungrounded word choice.
- `skills/commit/SKILL.md`: add a third Branch Handling case for feature branches whose existing commits are unrelated to the current changes. The new case branches off `origin/<default>` directly so uncommitted work is never carried through the local default branch. Also renames "staged changes" to "current changes" across Step 2, since staging only happens in Step 4.

fixes #105

🤖 Generated with [Claude Code](https://claude.ai/code)