### PR TITLE
chore: drop Glob/Grep tool references

### DIFF
--- a/.claude/rules/tool-usage.md
+++ b/.claude/rules/tool-usage.md
@@ -2,15 +2,10 @@
 
 Use dedicated tools instead of Bash equivalents.
 
-| Operation      | Dedicated tool | Bash (denied in settings.json) |
-| -------------- | -------------- | ------------------------------ |
-| File search    | Glob           | `find`                         |
-| Content search | Grep           | `grep`, `rg`                   |
-| Read files     | Read           | `cat`                          |
-| Edit files     | Edit           | `sed`, `awk`                   |
-
-If Glob or Grep returns no results, adjust the pattern or search
-path and retry. Do not fall back to Bash alternatives.
+| Operation  | Dedicated tool | Bash (denied in settings.json) |
+| ---------- | -------------- | ------------------------------ |
+| Read files | Read           | `cat`                          |
+| Edit files | Edit           | `sed`, `awk`                   |
 
 When a dedicated tool returns a precondition error (e.g., "file not
 read yet"), satisfy the precondition and retry. For example, if Edit

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,9 +41,6 @@
       "Bash(git switch --discard-changes*)",
       "Bash(git * --no-gpg-sign*)",
       "Bash(git * -c commit.gpgsign=false*)",
-      "Bash(grep *)",
-      "Bash(find *)",
-      "Bash(rg *)",
       "Bash(sed *)",
       "Bash(cat *)",
       "Bash(awk *)"

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -81,9 +81,9 @@ in this update", "Previously Y was broken").
    - Announce which commit message was chosen as the title
 
 2. Select template:
-   Use Glob to search for a project-level PR template:
+   Search for a project-level PR template using `find`:
    ```
-   Glob pattern: **/pull_request_template.md
+   find . -iname 'pull_request_template.md'
    ```
    If multiple files match, prefer the one closest to the repository
    root (fewest path segments).


### PR DESCRIPTION
# Summary

Adapt the Claude Code configuration to the native macOS / Linux build's removal of Glob and Grep as dedicated tools.

# Motivation

Starting with v2.1.117, the native macOS / Linux build routes `find` / `grep` / `rg` through embedded bfs / ugrep via Bash rather than exposing Glob and Grep as dedicated tools. The tool-usage rule, publish skill, and settings.json deny list still assumed the old model, so search commands were unusable from the main agent.

# Changes

- `.claude/rules/tool-usage.md`: Remove the Glob / Grep entries; retain Read / Edit guidance and the precondition-error note.
- `.claude/settings.json`: Drop `Bash(find *)`, `Bash(grep *)`, `Bash(rg *)` from the deny list.
- `.claude/skills/publish/SKILL.md`: Replace the Glob tool step for PR-template lookup with `find -iname`.

🤖 Generated with [Claude Code](https://claude.ai/code)
