### PR TITLE
docs: use HEREDOC for gh body in publish and retro

### DIFF
--- a/.claude/rules/writing-style-ja.md
+++ b/.claude/rules/writing-style-ja.md
@@ -1,4 +1,4 @@
-# Japanese Text Formatting
+# Writing Style (Japanese)
 
 Apply to all Japanese prose text (documents, comments, descriptions).
 
@@ -24,6 +24,26 @@ Complete sentences properly. Don't end with colons:
 
 - OK: `テーブル間の関係をまとめると以下のようになります。`
 - NG: `テーブル間の関係をまとめると:`
+
+## Vocabulary
+
+Prefer plain Japanese over katakana/English loanwords when natural
+Japanese exists. Established technical terms (`JSON`, `API`, `Pull
+Request`, etc.) are fine.
+
+- OK: `事前に存在していたカバレッジの欠落を解消する`
+- NG: `pre-existing なカバレッジの gap を close する`
+
+Do not use Japanese words that are unnatural in technical context.
+Heuristic: "would a native speaker find this natural?"
+
+- OK: `新しい名前`
+- NG: `新名` (reads as a surname or archaic in technical writing)
+
+## Style Consistency
+
+When editing existing Japanese text, match the established formality
+(です/ます vs である/だ). Never mix within the same context.
 
 ## Scope
 

--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -55,10 +55,9 @@ Signs of ungrounded word choice:
 
 ## Style Consistency
 
-When editing existing text, match the established style:
-
-- **Japanese**: Match formality (です/ます vs である/だ). Never mix within the same context.
-- **English**: Match tone and voice (formal, casual, technical).
+When editing existing text, match the established tone and voice
+(formal, casual, technical). For language-specific axes (e.g.,
+Japanese formality), see the language-specific style files.
 
 ## Redundancy
 

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -114,6 +114,25 @@ in this update", "Previously Y was broken").
 
 **IMPORTANT**: Always read the selected template file before creating the PR description.
 
+When passing the body to `gh pr create` or `gh pr edit`, use a HEREDOC
+inline within the command. Do not stage the body to a local file
+(e.g. `/tmp/pr-body.md`) and pass it via `--body-file <path>`.
+
+OK:
+
+```bash
+gh pr create --title "..." --body-file - <<'EOF'
+body content here
+EOF
+```
+
+NG: `Write /tmp/pr-body.md`, then `gh pr create --title "..." --body-file /tmp/pr-body.md`
+
+The user reviews tool calls before they run. Inline HEREDOC puts the
+body in the call so they see it before approving. A separate Write
+step bypasses this — once the file exists, the follow-up `gh` call
+sends content the user has not yet reviewed.
+
 ## 4. Final Output
 
 - Display the PR URL

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -84,7 +84,10 @@ Do not proceed to Step 5 until the user approves the plan.
 
 Create an issue on the dotfiles repository.
 
-**With `gh`**: use `--body-file` with a heredoc to prevent shell expansion of special characters in the body.
+**With `gh`**: use a HEREDOC inline within the command. Do not stage
+the body to a local file (e.g. `/tmp/issue-body.md`) — once the file
+exists, the follow-up `gh` call sends content the user has not yet
+reviewed.
 
 ```bash
 gh issue create -R yusuke-suzuki/dotfiles \


### PR DESCRIPTION
# Summary

Implements two countermeasures from issue #109 (CM1, CM2). CM3 was
intentionally dropped — see Motivation.

# Motivation

Issue #109 collected three countermeasures from a previous session's
violations:

- **CM1** — `--body-file` calls let an intermediate `/tmp/*.md`
  buffer slip past the user's tool-call review.
- **CM2** — Japanese prose drifted into katakana/loanwords and
  unnatural Japanese (`新名` etc.) where natural Japanese existed.
- **CM3** — Staging markers ("まず", "最初に") were read too broadly,
  bundling downstream changes that were not asked for.

CM1 and CM2 land here. CM3 is dropped because the existing plan-mode
workflow already requires explicit scope declaration before
non-trivial work; if a future session shows the same scope-creep
pattern slipping through plan mode, CM3 can be revisited then.

# Changes

## CM1 — HEREDOC inline for gh body content

- `/publish` and `/retro` skills now require HEREDOC inline within
  the `gh` command instead of staging the body to a local file
- Wording is shared between the two skills so the rule reads the
  same regardless of which workflow you enter from
- `/resolve-comments` is unaffected (it uses `-f body=...`, not
  `--body-file`)

## CM2 — Japanese style rules

- Add a `Vocabulary` section: prefer plain Japanese over
  katakana/loanwords when natural Japanese exists; avoid words
  that are unnatural in technical context
- Rename `text-formatting-ja.md` → `writing-style-ja.md` so the
  filename mirrors `writing-style.md` and reflects the broader scope
- Move the Japanese formality bullet from `writing-style.md`'s
  Style Consistency section into the renamed file, keeping each
  language's specifics with the language

closes #109

🤖 Generated with [Claude Code](https://claude.ai/code)
