### PR TITLE
docs: address retro #113 root causes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,6 +15,13 @@ Before modifying any file — including renaming, moving, or restructuring
 — read its full content first. Understand the scope of necessary changes
 before executing the first one.
 
+When the task is a rename, API migration, or call-site replacement,
+grep for the target symbol (method name, constant, type, string
+literal) across the repository before fixing the PR scope. Explicitly
+list which occurrences are in scope and which are out of scope. A
+scope description built from "the call sites I happened to see"
+misses the call sites a grep would have surfaced.
+
 ## Calibrated Decision Making
 
 Decision depth should be proportional to the scope of impact and irreversibility.

--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -44,3 +44,22 @@ reword and re-execute. Before the next attempt, output:
 
 Applies equally to tool rejection reasons, conversational pushback,
 and follow-up questions that imply the prior choice was unconsidered.
+
+## Self-review before submitting
+
+Before sending each draft (PR description, commit message, headings,
+review replies), do one read-through over your own output checking:
+
+1. **Sentence structure** — subject / object alignment, particle
+   choice in Japanese, grammar in English. Read each sentence as if
+   encountering it for the first time.
+2. **Technical accuracy** — claims about behavior, scope, and
+   history match the source. See `feedback-handling.md` "Verify
+   before answering".
+3. **Redundancy and noise** — sections that duplicate the change
+   list or restate self-evident information. See `writing-style.md`
+   "Redundancy".
+
+Apply this pass regardless of draft length. Raise priority on the
+axis where the user pushed back most recently — repeated failures on
+the same axis indicate the self-review pass missed it last time.

--- a/.claude/rules/feedback-handling.md
+++ b/.claude/rules/feedback-handling.md
@@ -18,12 +18,25 @@ One-off factual memories the user explicitly asks to save (e.g. "remember
 that the Grafana dashboard is at X") fall outside this rule — it
 targets behavioral corrections, not factual capture.
 
-## Verify before explaining your own actions
+## Verify before answering
 
-When asked about the cause of your own prior action ("why did you do
-X?"), do not answer from reconstruction or guesswork. Verify against
-the actual record — tool call history, referenced context, file state
-— before responding.
+When responding from your own knowledge or reconstruction, verify
+against the actual source before answering. The following situations
+require verification:
 
-If verification is not possible in the current context, say so
-explicitly rather than offering a plausible-sounding guess.
+1. **Explaining your own prior actions** — when asked about the
+   cause of your own prior action ("why did you do X?"), verify
+   against the actual record (tool call history, referenced context,
+   file state). If verification is not possible in the current
+   context, say so explicitly rather than offering a
+   plausible-sounding guess.
+2. **Answering questions about a rule, config, or spec** — read the
+   relevant file first. Do not paraphrase from memory when the
+   source is accessible.
+3. **Stating a technical fact** (numeric boundary, semantics,
+   naming, history) — verify against source code or `git log`
+   rather than relying on recollection.
+4. **Carrying subagent output into a deliverable** — when
+   incorporating Plan / Explore agent reports into a PR description,
+   commit message, or code, re-verify the technical claims against
+   the source. Subagent output is unverified until you check it.

--- a/.claude/rules/writing-style-ja.md
+++ b/.claude/rules/writing-style-ja.md
@@ -2,6 +2,50 @@
 
 Apply to all Japanese prose text (documents, comments, descriptions).
 
+## Tone
+
+Avoid Japanese-specific exaggerated expressions. They overstate the
+change and weaken precise technical claims. This is the Japanese
+counterpart to `writing-style.md` "Tone".
+
+Avoid:
+
+- 「完全に〜する」「徹底的に〜する」「全く〜ない」「絶対に〜」
+- 「断ち切る」「一掃する」「根絶する」
+
+Use specific, quantitative wording instead:
+
+- OK: `フォールバックを 2 箇所削除した`
+- NG: `フォールバックを完全に断ち切った`
+
+## Relative References
+
+Replace relative pointers with concrete references (class name, method
+name, PR number, commit id). Time-relative references rot when the
+document is read later, since "現在" and "今後" lose their anchor as
+time passes.
+
+Avoid:
+
+- 時間的相対参照: 「以前」「現在」「今後」「経過措置として残置」
+- 新旧の相対参照: 「旧」「新」「新旧」
+- 方向的な相対参照: 「〜側」「〜方向の挙動」
+
+時間的相対参照:
+
+- OK: `この処理は issue #123 の解消後に削除する`
+- NG: `この処理は今後削除する`
+
+新旧の相対参照:
+
+- OK: `PR #100 で導入された FooClient の delegate を BarClient に切り替える`
+- NG: `旧 client から新 client に切り替える`
+
+方向的な相対参照:
+
+- OK: `Foo#bar の戻り値が変わる`
+- NG: `Foo 側の挙動が変わる`
+
 ## Spacing
 
 Add half-width spaces around alphanumeric/English and markdown links:


### PR DESCRIPTION
# Summary

Update CLAUDE.md and three rule files to close gaps surfaced in retro #113. The changes target verification scope, Japanese tone, refactor-scope description, and self-review before submitting drafts.

# Motivation

Issue #113 collected eleven violations and grouped them into root causes that pointed at gaps in the existing rules. The existing `feedback-handling.md` "Verify before explaining your own actions" was scoped only to explaining prior actions and did not cover other situations where the same failure mode appears (rule questions, technical-fact claims, subagent output). `writing-style-ja.md` lacked a tone counterpart to the English `writing-style.md` and did not address relative references. `CLAUDE.md` "Read Before Modifying" did not require a grep over the target symbol when describing refactor scope. `communication.md` did not codify a self-review pass over one's own draft.

# Changes

- `feedback-handling.md`: rename "Verify before explaining your own actions" to "Verify before answering" and enumerate four situations requiring verification (prior actions, rule/spec questions, technical facts, subagent output).
- `writing-style-ja.md`: add `Tone` section listing Japanese-specific exaggerated expressions to avoid.
- `writing-style-ja.md`: add `Relative References` section instructing replacement of time-relative, old/new, and directional pointers with concrete references.
- `CLAUDE.md`: extend `Read Before Modifying` to require a grep over the target symbol when describing refactor scope.
- `communication.md`: add `Self-review before submitting` section with a three-axis read-through (sentence structure, technical accuracy, redundancy).

closes #113

🤖 Generated with [Claude Code](https://claude.ai/code)
