### PR TITLE
docs: address retro #114 root causes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,6 +22,12 @@ list which occurrences are in scope and which are out of scope. A
 scope description built from "the call sites I happened to see"
 misses the call sites a grep would have surfaced.
 
+When working from a design document or specification, quote the
+relevant passages for "when", "who", and "which flow" preconditions
+in your response, then state your interpretation. Present the
+"doc passage → interpretation" pair to the user before proceeding
+to design. A misread precondition compounds through the design.
+
 ## Calibrated Decision Making
 
 Decision depth should be proportional to the scope of impact and irreversibility.
@@ -52,6 +58,51 @@ constraints and side effects of each candidate and check them against
 the current state. Skipping this step produces "jump from shallow
 comparison to action" — the very failure mode that deliberation is
 meant to prevent.
+
+### Citing existing patterns
+
+Before citing "this is the project convention" or "this is how
+existing code does it":
+
+1. **Verify the count.** At least 3 occurrences via `grep` or
+   `find` are required to claim a convention. A single example
+   is one data point; two examples may or may not indicate a
+   pattern.
+2. **Evaluate the pattern's quality.** Existing code is a
+   starting point, not a justification. Following existing code
+   without quality assessment compounds technical debt — a
+   pattern that fit one context may not fit the current change.
+
+This applies to file placement, naming, library choice,
+error-handling style, and similar appeals to precedent.
+
+## Technical Decision Heuristics
+
+Apply these heuristics when designing or evaluating an
+implementation. Each is a question to ask, not a doctrine — a
+decision that fails one heuristic may still be correct, but the
+trade-off should be conscious.
+
+- **SRP (Single Responsibility)** — Does this class or function
+  do one thing? When responsibilities mix, the unit becomes
+  harder to name accurately and harder to change for one reason
+  at a time.
+- **YAGNI (You Aren't Gonna Need It)** — Is this code needed by
+  a current requirement? Hypothetical future use cases produce
+  abstractions that fit no real call site.
+- **SoT (Single Source of Truth)** — Is this fact stored or
+  derived in exactly one place? Duplicated state drifts.
+- **Public / internal boundaries** — Is the surface exposed to
+  callers minimal? Internal helpers leaking out becomes the
+  default API once they are referenced.
+- **Lazy evaluation** — Does this run only when needed? Eager
+  computation in constructors and module load wastes work and
+  surfaces unrelated errors at startup.
+- **Existing-pattern evaluation** — Has the cited pattern been
+  evaluated, or is it just convenient? See "Calibrated Decision
+  Making → Citing existing patterns".
+- **Unnecessary abstraction** — Does this layer earn its
+  complexity? Three similar lines beat a premature wrapper.
 
 ## Professional Ownership
 
@@ -84,6 +135,20 @@ meant to prevent.
 - ❌ "Which approach is better?"
 - ❌ "Is this okay?"
 
+### Self-check before invoking AskUserQuestion
+
+Before calling AskUserQuestion, answer two questions internally:
+
+1. **Can I decide this?** Implementation details — naming,
+   structure, library choice, configuration values — fall under
+   "What YOU decide" and must not be delegated.
+2. **Can investigation resolve this?** If reading code, running
+   `grep`, or testing an approach can produce the answer, do
+   that first. Delegating to the user without investigation
+   shifts work that the source-of-truth could resolve directly.
+
+Use AskUserQuestion only after both checks fail.
+
 ### User examples are constraints, not prescriptions
 
 When the user illustrates intent with an example ("I mean something
@@ -92,6 +157,24 @@ the final wording or design. Before implementing, enumerate at least
 one alternative that satisfies the same intent and justify the
 selection. Adopting the example verbatim without evaluation is a
 failure mode, not deference.
+
+## Default to writing no comments
+
+Default to writing no comments. Add a comment only when the WHY is
+non-obvious — a hidden constraint, a subtle invariant, a workaround
+for a specific bug, behavior that would surprise a reader. If
+removing the comment would not confuse a future reader, do not
+write it.
+
+Do not explain WHAT the code does — well-named identifiers already
+do that. Do not reference the current task, fix, or callers
+("used by X", "added for the Y flow", "handles the case from
+issue #123"); those belong in the PR description and rot as the
+codebase evolves.
+
+After writing a comment, self-check: does this explain WHY? Would
+removing it confuse a future reader? If both answers are no, delete
+it.
 
 ## Prefer Standards
 

--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -45,6 +45,16 @@ reword and re-execute. Before the next attempt, output:
 Applies equally to tool rejection reasons, conversational pushback,
 and follow-up questions that imply the prior choice was unconsidered.
 
+## Renames and structural changes
+
+For renames, file moves, and type reorganizations, present at least
+three candidates with a short trade-off table on the first proposal,
+not only after rejection. Naming and structural decisions are
+reject-prone because the user often has a stronger opinion than the
+proposer and small wording shifts produce large readability
+differences. Adopting a single in-mind candidate without comparison
+is the failure mode this rule prevents.
+
 ## Self-review before submitting
 
 Before sending each draft (PR description, commit message, headings,

--- a/.claude/rules/feedback-handling.md
+++ b/.claude/rules/feedback-handling.md
@@ -40,3 +40,18 @@ require verification:
    incorporating Plan / Explore agent reports into a PR description,
    commit message, or code, re-verify the technical claims against
    the source. Subagent output is unverified until you check it.
+
+## Suppress test execution during design discussions
+
+While the user is iterating on a design (back-and-forth on naming,
+structure, or approach — "discussion mode"), refrain from running
+tests, builds, or other expensive verifications until the
+discussion settles or the user explicitly requests them.
+
+Running tests during design iteration:
+
+- Slows the conversation while the design is still moving.
+- Suggests confidence in a draft that may still change.
+- Pulls focus from the design question to test output.
+
+Resume normal verification once the design is agreed.

--- a/.claude/rules/naming.md
+++ b/.claude/rules/naming.md
@@ -1,0 +1,58 @@
+# Naming
+
+Apply when naming functions, classes, types, files, configurations,
+or any identifier future readers will encounter.
+
+## Two evaluation axes
+
+Evaluate every name on two independent axes. A name that scores
+well on one and poorly on the other still needs revision.
+
+### Semantic Fit
+
+Does the name use domain-idiomatic vocabulary? A name with the
+right shape but wrong domain words misleads more than it clarifies.
+
+- Verbs and nouns should come from the domain the code operates
+  in (HTTP, queueing, persistence, billing) — not from a generic
+  "what the code does" reading.
+- Distinct concepts within the same module must use distinct
+  vocabulary. Reusing the same noun for unrelated meanings forces
+  readers to disambiguate from context.
+
+### Linguistic Naturalness
+
+Is the name natural English? Awkward structure slows reading even
+when each individual word is correct.
+
+- Avoid noun stacks longer than three words. `UserProfileImage`
+  is fine; `UserProfileImageCacheRefreshScheduler` reads as a
+  paragraph.
+- Avoid non-idiomatic verb choices. `getX` for things that are not
+  retrievals, `processX` for anything generic, and `handleX` for
+  catch-all methods all conceal what the code actually does.
+- Match common collocations. Prefer `cancel` over `abort` for a
+  user-initiated stop; `retry` over `redo` for a transient
+  failure; `dispose` over `cleanup` for resource release.
+
+## Critical evaluation of existing names
+
+When extending, renaming, or duplicating an existing name, do not
+assume the existing name is correct.
+
+- Read the call sites and the type's behavior. The original name
+  may have drifted from the actual responsibility.
+- Citing an existing name as precedent ("we already call it `Foo`
+  elsewhere") is not justification. See `CLAUDE.md` "Calibrated
+  Decision Making → Citing existing patterns".
+- A rename worth doing once is worth a 3-candidate trade-off
+  table. See `communication.md` "Renames and structural changes".
+
+## Naming process
+
+1. List at least 3 candidates.
+2. Evaluate each on Semantic Fit and Linguistic Naturalness.
+3. State the recommended choice and the rejected ones with
+   reasons.
+4. Apply this comparison on the first proposal, not after
+   rejection.

--- a/.claude/rules/writing-style-ja.md
+++ b/.claude/rules/writing-style-ja.md
@@ -72,17 +72,49 @@ Complete sentences properly. Don't end with colons:
 ## Vocabulary
 
 Prefer plain Japanese over katakana/English loanwords when natural
-Japanese exists. Established technical terms (`JSON`, `API`, `Pull
-Request`, etc.) are fine.
+Japanese exists. Acceptable katakana and English terms are
+restricted to established technical proper nouns (`JSON`, `API`,
+`Pull Request`, etc.). Abstract concepts written in katakana should
+be replaced with plain Japanese.
 
 - OK: `事前に存在していたカバレッジの欠落を解消する`
 - NG: `pre-existing なカバレッジの gap を close する`
+
+Common abstract loanwords and their Japanese equivalents:
+
+| 避ける表現 | 置き換え候補 |
+| --- | --- |
+| 「シンプル」 | 「単純」「簡潔」 |
+| 「クリア」 | 「明確」「明瞭」 |
+| 「アプローチ」 | 「方針」「方法」 |
+| 「コンテキスト」 | 「文脈」 |
+| 「ニュアンス」 | 「意味合い」「微妙な違い」 |
+| 「フィット」 | 「合う」「適する」 |
+| 「レイヤ」 | 「層」 |
+| 「メリット」「デメリット」 | 「利点」「欠点」 |
+| 「カテゴリー」 | 「分類」「区分」 |
+| 「マッピング」 | 「対応付け」 (コード内のマップデータ構造を指す場合は除く) |
+| 「ロジック」 | 「処理」「論理」 (技術文脈の固有語を除き、抽象的な利用を避ける) |
 
 Do not use Japanese words that are unnatural in technical context.
 Heuristic: "would a native speaker find this natural?"
 
 - OK: `新しい名前`
 - NG: `新名` (reads as a surname or archaic in technical writing)
+
+### Mixed-construct rules
+
+When embedding English nouns in Japanese sentences, supply the
+required particles and do not end the sentence on a noun
+(体言止め). Missing particles and 体言止め read as note fragments
+rather than complete sentences.
+
+- NG: 「`Foo` だけ root namespace 直接」
+- OK: 「`Foo` だけ root の namespace を直接参照する」
+- NG: 「内部用 wrapper 削除」
+- OK: 「内部用の wrapper を削除する」
+- NG: 「`Bar` wrapper だけ」
+- OK: 「`Bar` 用の wrapper だけ」
 
 ## Style Consistency
 


### PR DESCRIPTION
# Summary

Update CLAUDE.md and four rule files (one new) to close gaps surfaced in retro #114. The changes consolidate deliberation cadence, evidence thresholds for convention citations, technical decision heuristics, Japanese tone and mixed-construct rules, comment defaults, and naming guidance.

# Motivation

Issue #114 collected eleven violations across eight root causes. Each root cause maps to a missing or incomplete rule:

- Deliberation was skipped before naming, restructuring, and AskUserQuestion calls.
- Project conventions were claimed from one or two examples; existing patterns were cited without quality assessment.
- Design-document preconditions were misread without close reading of the relevant passages.
- Japanese tone tolerated katakana overuse and English-noun fragments missing particles or ending in 体言止め.
- Test execution interrupted ongoing design discussions.
- Comments explained WHAT instead of WHY.
- Technical design heuristics (SRP, YAGNI, SoT, etc.) were applied ad hoc without a checklist.
- Naming had no evaluation criteria or dedicated rule file.

# Changes

- `CLAUDE.md` "Read Before Modifying": add a paragraph requiring "doc passage → interpretation" pairs before designing from a spec.
- `CLAUDE.md` "Calibrated Decision Making": add `Citing existing patterns` subsection (3-occurrence evidence threshold + quality evaluation).
- `CLAUDE.md`: add `Technical Decision Heuristics` section covering SRP, YAGNI, SoT, public/internal boundaries, lazy evaluation, existing-pattern evaluation, and unnecessary abstraction.
- `CLAUDE.md` "Professional Ownership": add `Self-check before invoking AskUserQuestion` subsection.
- `CLAUDE.md`: add `Default to writing no comments` section.
- `communication.md`: add `Renames and structural changes` section requiring a 3-candidate trade-off table on the first proposal.
- `writing-style-ja.md` "Vocabulary": add loanword correspondence table; restrict acceptable katakana and English terms to established technical proper nouns; add `Mixed-construct rules` subsection forbidding particle omission and 体言止め in English-noun-embedded sentences.
- `feedback-handling.md`: add `Suppress test execution during design discussions` section.
- `naming.md` (new): add naming guidelines with two evaluation axes (Semantic Fit / Linguistic Naturalness) and critical evaluation of existing names.

closes #114

🤖 Generated with [Claude Code](https://claude.ai/code)
