### PR TITLE
docs: address retro #117 root causes

### DIFF
--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -45,6 +45,29 @@ reword and re-execute. Before the next attempt, output:
 Applies equally to tool rejection reasons, conversational pushback,
 and follow-up questions that imply the prior choice was unconsidered.
 
+### A question is not an instruction
+
+When the user asks "why did you choose X?", "is this accurate?", or
+"why is this 'direct'?", the request is for the rationale behind X,
+not a directive to remove or replace X. The proper sequence:
+
+1. **State the rationale** — articulate why X was chosen,
+   referencing the specific structure, constraint, or evidence that
+   produced the choice.
+2. **Defend it if it holds** — if the rationale stands up to the
+   question, say so and explain why. The question may have been a
+   probe, not a rejection.
+3. **Revise only if the rationale fails** — and when revising,
+   address the specific failure surfaced by the question, not the
+   surface word. If the question reveals that "direct" was framed
+   against a non-existent contrast, the fix is to drop the
+   contrast framing, not to swap "direct" for a synonym.
+
+Mechanically removing or replacing the questioned word without
+first stating the rationale leaves the user without an answer to
+their actual question and tends to introduce a new word with the
+same underlying problem.
+
 ## Renames and structural changes
 
 For renames, file moves, and type reorganizations, present at least

--- a/.claude/rules/feedback-handling.md
+++ b/.claude/rules/feedback-handling.md
@@ -30,6 +30,13 @@ require verification:
    file state). If verification is not possible in the current
    context, say so explicitly rather than offering a
    plausible-sounding guess.
+
+   This includes the case where your own posted output appears to
+   have been modified externally. Verify by comparing what was
+   sent (tool call arguments, prior message) against what now
+   exists on the remote. Do not produce plausible-sounding guesses
+   like "the system seems to have modified it" — fetch the current
+   state and the original payload, then state the diff factually.
 2. **Answering questions about a rule, config, or spec** — read the
    relevant file first. Do not paraphrase from memory when the
    source is accessible.

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -21,3 +21,23 @@ is part of the `/commit` workflow when on master/main.
 
 Always use the `/publish` skill instead of running `git push` directly.
 The skill keeps the PR description in sync with the current diff.
+
+## Editing published artifacts
+
+When editing artifacts already on the remote — PR descriptions, PR
+titles, issue bodies, review comments, commit messages on a pushed
+branch — treat the remote as the single source of truth. Fetch the
+current state before producing the edit:
+
+- PR description / title: `gh pr view <number>` (or the GitHub MCP
+  `pull_request_read` tool)
+- Issue body: `gh issue view <number>`
+- Review comment: `gh api repos/<owner>/<repo>/pulls/comments/<comment-id>`
+- Pushed commit message: `git fetch && git show origin/<branch>`
+
+Session memory is not a substitute for the fetch. Between the time a
+draft was last seen and the time an edit is composed, the remote may
+have been updated by a reviewer, by a CI bot, by a prior tool call
+whose output was not retained, or by an external edit. Composing the
+edit against an outdated mental snapshot overwrites those changes
+silently.

--- a/.claude/rules/writing-style-ja.md
+++ b/.claude/rules/writing-style-ja.md
@@ -79,6 +79,10 @@ be replaced with plain Japanese.
 
 - OK: `事前に存在していたカバレッジの欠落を解消する`
 - NG: `pre-existing なカバレッジの gap を close する`
+- OK: 「該当する項目を確認する」
+- NG: 「該当 bullet を確認する」 (`bullet` は「項目」と書ける)
+- OK: 「閾値との差」
+- NG: 「閾値までの距離」
 
 Common abstract loanwords and their Japanese equivalents:
 
@@ -95,12 +99,15 @@ Common abstract loanwords and their Japanese equivalents:
 | 「カテゴリー」 | 「分類」「区分」 |
 | 「マッピング」 | 「対応付け」 (コード内のマップデータ構造を指す場合は除く) |
 | 「ロジック」 | 「処理」「論理」 (技術文脈の固有語を除き、抽象的な利用を避ける) |
+| 「クランプ」 | 「制限する」「収める」 (CSS `clamp()` 等の固有語を除き、抽象的な利用を避ける) |
 
 Do not use Japanese words that are unnatural in technical context.
 Heuristic: "would a native speaker find this natural?"
 
 - OK: `新しい名前`
 - NG: `新名` (reads as a surname or archaic in technical writing)
+- OK: `生の値`
+- NG: `素値` (coined contraction; not idiomatic Japanese)
 
 ### Mixed-construct rules
 
@@ -115,6 +122,51 @@ rather than complete sentences.
 - OK: 「内部用の wrapper を削除する」
 - NG: 「`Bar` wrapper だけ」
 - OK: 「`Bar` 用の wrapper だけ」
+
+### Question literal katakana
+
+Words that are merely English transliterations into katakana
+(「トリビアル」「ラッパー」「アグリゲーター」「クランプ」, etc.)
+read as direct transcriptions rather than established technical
+terms. Before writing such a word, check whether plain Japanese
+conveys the same meaning.
+
+- OK: 「単純な実装」「委譲を行うクラス」「集約処理」「値を範囲に収める」
+- NG: 「トリビアルな実装」「ラッパークラス」「アグリゲーター処理」「値をクランプする」
+
+Established technical proper nouns (`JSON`, `API`, `Pull Request`,
+`HTTP`, CSS `clamp()`, etc.) remain in their original form. This
+subsection applies only to words that have a plain Japanese
+equivalent.
+
+### Don't translate English syntax mechanically
+
+Translating "X of Y" mechanically into 「Y の X」 can invert the
+modifier-of relationship between X and Y. Before settling on the
+Japanese order, determine which side contains the other and which
+side is contained.
+
+- OK: 「`FooClient` が公開する API」 (`FooClient` owns the API)
+- NG: 「公開 API の `FooClient` ラッパークラス」 (inverts the
+  relationship — reads as if the API owns `FooClient`)
+
+Before stringing together English noun phrases in Japanese,
+confirm you can state the relationship explicitly as either "X が
+Y を 〜する" or "Y は X の一部である".
+
+### Apply the same vocabulary check inside vocabulary discussions
+
+In conversations where word choice itself is the topic (replies
+to feedback about vocabulary, for example), it is easy to coin
+fresh unnatural katakana or direct translations inside the very
+reply that addresses the feedback. Apply this section's checks
+and `writing-style.md` "Vocabulary Grounding" to those replies in
+particular.
+
+Before sending the reply, read it in isolation and confirm no new
+katakana transliterations or direct translations have been
+introduced. Do not let the surrounding feedback context lower the
+vocabulary bar.
 
 ## Style Consistency
 

--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -53,6 +53,57 @@ Signs of ungrounded word choice:
 - Dismissive or approving labels presented as facts without evidence
   ("that candidate is brittle", "this approach is clean")
 
+### Modifier-of relationships
+
+For "X of Y" / "X's Y" / possessive forms, verify which side is the
+container and which is the contained before writing. The same words
+in opposite order describe opposite structures, and the wrong order
+inverts the technical claim.
+
+Before using a possessive form, answer:
+
+- Does X contain Y, or does Y represent X?
+- Which side is the public surface, and which is the implementation
+  detail?
+
+- OK: `the public API exposed by FooClient` (FooClient owns the API)
+- NG: `FooClient is the wrapper class of the public API` (inverts
+  the relationship — the API does not own a wrapper; the wrapper
+  exposes the API)
+
+### Borrowed expressions need re-verification
+
+Phrasings copied from other reviewers, bots, prior documents, or
+the surrounding conversation are not pre-verified. The originating
+context may differ from yours, and grammatical inversions can be
+preserved without notice.
+
+Before reusing a borrowed phrase, run the same Vocabulary Grounding
+checks as for original wording: Is each word grounded? Does the
+modifier-of relationship match the structure being described? Does
+the phrase carry an evaluative claim that needs evidence?
+
+### Pre-publication vocabulary check
+
+Before sending text containing any of the following, run a
+last-pass check:
+
+1. **Evaluative adjectives** (`thin`, `trivial`, `obvious`,
+   `clean`, `brittle`, `important`) — replace with a concrete
+   indicator (line count, dependency count, named property), or
+   delete if the indicator does not exist.
+2. **Technical contrasts** (`direct vs. indirect`, `sync vs.
+   async`, `eager vs. lazy`) — verify the contrast against the
+   actual structure. If both sides do not exist in the code, the
+   contrast is false framing.
+3. **Less-common words** — confirm a plain alternative does not
+   convey the same meaning. If a plain word works, prefer it.
+
+- OK: `FooClient delegates to BarClient via a single method call`
+- NG: `FooClient is a thin wrapper that directly invokes BarClient`
+  ("thin" lacks a concrete indicator; "directly" implies a
+  contrast with an indirect path that does not exist)
+
 ## Style Consistency
 
 When editing existing text, match the established tone and voice

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -55,6 +55,13 @@ gh pr list --head <current-branch> --limit 1
   ```
 
   **With GitHub MCP**: use the `pull_request_read` tool with owner, repo, and the PR number.
+
+  **MANDATORY**: This fetch is required before any edit to the PR
+  description, regardless of what is remembered from earlier in the
+  conversation. Session memory is not a substitute — the remote may
+  have been updated by review, by another tool, or by a prior edit
+  that did not reach the local conversation. Skipping this step
+  produces edits that overwrite or contradict the live description.
 - Compare with the actual changes (`git diff <default>...HEAD`)
 - Update description if it doesn't accurately reflect the changes:
 


### PR DESCRIPTION
# Summary

Update five rule files and the publish skill to close gaps surfaced in retro #117. The changes tighten vocabulary verification before publication, require a remote-state fetch before editing published artifacts, and clarify how to respond when a question is mistaken for a directive.

# Motivation

Issue #117 collected eleven violations across three root cause groups. Each group maps to a missing or incomplete rule:

- **Vocabulary verification (violations 1-6, 10)** — Pre-publication checks did not catch unnatural katakana, evaluative adjectives without concrete indicators ("thin wrapper", "trivial-class"), or modifier-of relationships borrowed from review bots without independent verification ("the public API's wrapper class").
- **Skill workflow steps skipped (violation 7)** — The publish skill's `gh pr view` step was skipped on the basis of session memory, leaving the edit out of sync with the live remote.
- **Defensive replies and question-as-directive (violations 8, 9, 11)** — Questions about a word choice ("why is this 'direct'?") were read as directives to remove the questioned word, without first stating the rationale or addressing the framing surfaced by the question. Speculation about why posted output had been modified replaced verification against the actual record.

# Changes

- `writing-style.md` "Vocabulary Grounding": add `Modifier-of relationships`, `Borrowed expressions need re-verification`, and `Pre-publication vocabulary check` subsections, each with Bad/Good example pairs.
- `writing-style-ja.md` "Vocabulary": add `Question literal katakana`, `Don't translate English syntax mechanically`, and `Apply the same vocabulary check inside vocabulary discussions` subsections; add 「クランプ」 to the loanword table; expand top-level NG examples with 「該当 bullet」, 「閾値までの距離」, and 「素値」.
- `skills/publish/SKILL.md` Step 3: add a MANDATORY note that `gh pr view <number>` (or the GitHub MCP equivalent) must be run before editing the PR description, regardless of what is remembered from earlier in the conversation.
- `git.md`: add `Editing published artifacts` section requiring the remote state to be fetched before composing edits to PR descriptions, issue bodies, review comments, or pushed commit messages.
- `feedback-handling.md` "Verify before answering" #1: extend with the externally-modified-output case, requiring a sent-vs-current diff verification rather than plausible-sounding guesses.
- `communication.md`: add `A question is not an instruction` subsection requiring the rationale to be stated first when the user asks "why did you choose X?" or "is this accurate?", and revisions to address the specific failure surfaced by the question rather than the surface word.

closes #117

🤖 Generated with [Claude Code](https://claude.ai/code)
