### PR TITLE
docs: address retro #119 root causes

### DIFF
--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -41,6 +41,10 @@ reword and re-execute. Before the next attempt, output:
 3. **Alternatives considered** — when the revision is a matter of
    judgment rather than a clear fix, name at least one other option
    and why it was not chosen.
+4. **Premise that broke** — name the prior premise (assumption,
+   inferred constraint, design choice) the new feedback
+   invalidates. Without naming it, position shifts read as
+   arbitrary even when the new direction is correct.
 
 Applies equally to tool rejection reasons, conversational pushback,
 and follow-up questions that imply the prior choice was unconsidered.
@@ -78,6 +82,23 @@ proposer and small wording shifts produce large readability
 differences. Adopting a single in-mind candidate without comparison
 is the failure mode this rule prevents.
 
+## Reply length to PR / review comments
+
+Default to "conclusion + one-line rationale" for replies to PR
+review comments. The diff already carries most of the information;
+prose should add the reasoning the diff cannot show.
+
+Do not restate in prose:
+
+- What changed (the diff shows it)
+- Where the change is (the file and line are linked from the
+  comment)
+- That a suggestion was applied (the resolved state shows it)
+
+Add prose only when the rationale, trade-off, or remaining caveat
+is non-obvious from the diff alone. Length scales with the depth
+of the rationale, not with the size of the change.
+
 ## Self-review before submitting
 
 Before sending each draft (PR description, commit message, headings,
@@ -92,6 +113,11 @@ review replies), do one read-through over your own output checking:
 3. **Redundancy and noise** — sections that duplicate the change
    list or restate self-evident information. See `writing-style.md`
    "Redundancy".
+4. **Vocabulary discipline** — scan for metaphors, katakana
+   loanwords, and abstract jargon; replace with plain alternatives
+   where one conveys the same meaning. See `writing-style.md`
+   "Pre-publication vocabulary check" and `writing-style-ja.md`
+   "Question literal katakana".
 
 Apply this pass regardless of draft length. Raise priority on the
 axis where the user pushed back most recently — repeated failures on

--- a/.claude/rules/feedback-handling.md
+++ b/.claude/rules/feedback-handling.md
@@ -42,7 +42,11 @@ require verification:
    source is accessible.
 3. **Stating a technical fact** (numeric boundary, semantics,
    naming, history) — verify against source code or `git log`
-   rather than relying on recollection.
+   rather than relying on recollection. Before writing the claim,
+   record the specific file path and line range (or commit id)
+   the claim rests on as an internal note. A claim without a
+   concrete source pointer is unverified, regardless of how
+   confident the recollection feels.
 4. **Carrying subagent output into a deliverable** — when
    incorporating Plan / Explore agent reports into a PR description,
    commit message, or code, re-verify the technical claims against

--- a/.claude/rules/lint-suppression.md
+++ b/.claude/rules/lint-suppression.md
@@ -1,0 +1,37 @@
+# Lint Suppression
+
+Apply when adding any inline lint suppression comment
+(`# rubocop:disable`, `# eslint-disable`, `// noqa`, etc.).
+
+## Three checks before suppressing
+
+Before adding a suppression comment, answer all three questions.
+Suppression is allowed only when each can be answered concretely.
+
+1. **What does the rule prevent?** Name the specific failure mode
+   the rule was designed to catch (e.g., "this rule prevents
+   accidental shadowing of a standard library name"). If the
+   rule's intent cannot be stated, the suppression is uninformed.
+2. **Does an alternative implementation avoid the issue?** Try the
+   alternative first. Suppression is a last resort once the
+   alternative has been ruled out — not a first response to a
+   failing lint. If the alternative is rejected, name the reason
+   (cost, readability, scope) so the rejection is auditable.
+3. **Is the rule misapplied for this context?** Some rules
+   trigger on patterns the rule was not designed for (e.g., a
+   complexity metric counting boilerplate that has no real
+   complexity). When the rule is misapplied, suppression is
+   correct; when it is correctly flagging a real issue,
+   suppression hides the issue rather than fixing it.
+
+Suppression without all three checks passing is not allowed. The
+default response to a lint failure is to fix the underlying issue.
+
+## When suppressing
+
+Document the reason inline alongside the suppression comment, in
+the form "suppress because <reason from checks 2 or 3>". A
+suppression without an inline reason rots — the next reader
+cannot tell whether the rule was misapplied or whether the
+suppression was a shortcut, and removing the suppression to
+re-evaluate becomes risky.

--- a/.claude/rules/tool-usage.md
+++ b/.claude/rules/tool-usage.md
@@ -10,3 +10,32 @@ Use dedicated tools instead of Bash equivalents.
 When a dedicated tool returns a precondition error (e.g., "file not
 read yet"), satisfy the precondition and retry. For example, if Edit
 fails because the file was not read, use Read first, then retry Edit.
+
+## CLI body delivery
+
+When passing a user-facing body to `gh api`, `gh pr edit`,
+`gh pr create`, `gh issue create`, `gh issue comment`, or any
+similar command, supply the body inline via heredoc — not by
+writing the body to a temp file and reading it back. The body
+must be visible in the tool call itself so the user can review it
+before the call executes.
+
+OK — heredoc inline:
+
+```bash
+gh api ... -f body="$(cat <<'EOF'
+body content
+EOF
+)"
+```
+
+NG — temp file:
+
+```bash
+printf '...' > /tmp/body.md && gh api ... --input /tmp/body.md
+```
+
+Heredoc keeps the published artifact and the tool-call record
+aligned. Temp files hide the body from the tool call and force
+the user to open another file to audit what was sent. This
+applies to any CLI body, not just to the `publish` skill.


### PR DESCRIPTION
# Summary

Update three rule files and add one new rule file to close gaps surfaced in retro #119. The changes add a vocabulary axis to the self-review pass, require a concrete source pointer when stating technical facts, generalize the inline-heredoc requirement beyond the publish skill, codify when lint suppression is acceptable, require naming the broken premise when re-proposing, and bound reply length to PR review comments.

# Motivation

Issue #119 collected ten violations across six root cause groups. Each group maps to a missing or incomplete rule:

- **Vocabulary discipline (violations 1, 6)** — `writing-style.md` "Vocabulary Grounding" and `writing-style-ja.md` "Vocabulary" already prohibit metaphors and katakana loanwords, but the self-review checklist in `communication.md` did not include vocabulary as a dedicated axis, so the pre-send check was skipped.
- **Source verification (violations 2, 3, 8)** — `feedback-handling.md` "Verify before answering" #3 required verification against source for technical facts but had no operational handle (e.g., recording a file path / line range) before writing the claim, so claims grounded in recollection still passed the rule.
- **Temp-file dependence for CLI bodies (violation 7)** — The `publish` skill prohibits staging PR bodies to temp files, but the same prohibition was scoped to that skill alone and did not apply to other `gh` invocations (`gh api`, `gh issue create`, etc.).
- **Lint suppression (violation 9)** — No file in `~/.claude/rules/` covered the decision to add `# rubocop:disable` / `# eslint-disable` / equivalent. CLAUDE.md "Calibrated Decision Making" is generic and did not flag this anti-pattern.
- **Re-proposing without naming the broken premise (violation 10)** — `communication.md` "Re-proposing after rejection" required Assessment / What will change / Alternatives but did not require naming the prior premise the new feedback invalidates, so position shifts read as arbitrary.
- **Reply verbosity (violation 4)** — `writing-style.md` "Redundancy" exists but had no specific guidance for PR review replies, where the diff itself carries most of the information.

# Changes

- `communication.md` "Self-review before submitting": add fourth axis `Vocabulary discipline` cross-referencing `writing-style.md` "Pre-publication vocabulary check" and `writing-style-ja.md` "Question literal katakana".
- `communication.md` "Re-proposing after rejection": add fourth required item `Premise that broke` requiring the prior premise the new feedback invalidates to be named.
- `communication.md`: add `Reply length to PR / review comments` section establishing "conclusion + one-line rationale" as the default and listing what not to restate in prose.
- `feedback-handling.md` "Verify before answering" #3: require recording the specific file path and line range (or commit id) the claim rests on as an internal note before writing a technical-fact claim.
- `tool-usage.md`: add `CLI body delivery` section requiring inline heredoc (not temp files) when passing user-facing bodies to `gh api`, `gh pr edit`, `gh pr create`, `gh issue create`, `gh issue comment`, or similar commands.
- `lint-suppression.md` (new): add three required checks (rule intent, alternative implementation, rule misapplication) before adding a suppression comment, plus an inline-reason requirement when suppressing.

closes #119

🤖 Generated with [Claude Code](https://claude.ai/code)
