### PR TITLE
docs: address retro #123 root causes

### DIFF
--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -122,3 +122,17 @@ review replies), do one read-through over your own output checking:
 Apply this pass regardless of draft length. Raise priority on the
 axis where the user pushed back most recently — repeated failures on
 the same axis indicate the self-review pass missed it last time.
+
+### Iteration discipline
+
+After each rejection, run the full four-step pass on the next
+draft. Targeted edits often re-introduce issues on axes that were
+correct in the rejected version — rewording for vocabulary can
+break sentence structure, narrowing scope can lose technical
+accuracy.
+
+Repeated cross-axis failures in one thread (rejection #1 on
+technical accuracy, rejection #2 on vocabulary, rejection #3 on
+scope ambiguity) indicate the per-iteration pass is being skipped,
+not that the rules need to expand. Short reply iterations are not
+exempt from the full pass.

--- a/.claude/rules/feedback-handling.md
+++ b/.claude/rules/feedback-handling.md
@@ -60,6 +60,15 @@ require verification:
    examples mislead the user into trusting an unverified
    convention, and the fabrication often reads as analytical
    because the example "sounds right".
+6. **Responding to a reviewer's flagged scenario** — before
+   analyzing mechanisms, applying a defensive fix, or accepting a
+   reviewer's proposed change, verify whether the flagged scenario
+   can actually occur. Check the spec, naming constraints, type
+   system, or other invariants that may make the scenario
+   impossible. A theoretically valid concern about an impossible
+   scenario does not warrant a fix — reply with the constraint
+   that rules the scenario out, and stop. This applies equally to
+   human reviewers and automated bots.
 
 ## Suppress test execution during design discussions
 

--- a/.claude/skills/resolve-comments/SKILL.md
+++ b/.claude/skills/resolve-comments/SKILL.md
@@ -56,12 +56,18 @@ Format and display unresolved threads showing: author, file path, line number, d
 
 For each unresolved comment:
 
-1. Read the relevant source code to understand the full context
-2. Assess the feedback: Is it technically correct? Does it improve the code?
-3. Evaluate trade-offs: complexity, scope, practical impact
-4. Do not accept suggestions uncritically — weigh them against the
+1. Verify the premise: can the flagged scenario actually occur?
+   Check the spec, naming constraints, type system, or other
+   invariants. If the scenario is impossible, draft a "No change"
+   reply citing the constraint and skip the remaining steps for
+   this comment — a theoretically valid concern about an
+   impossible scenario does not warrant a fix.
+2. Read the relevant source code to understand the full context
+3. Assess the feedback: Is it technically correct? Does it improve the code?
+4. Evaluate trade-offs: complexity, scope, practical impact
+5. Do not accept suggestions uncritically — weigh them against the
    code's design intent and existing patterns
-5. Draft a recommended action: fix (with specific changes) or
+6. Draft a recommended action: fix (with specific changes) or
    explain why no change is needed (with rationale)
 
 ## 3. Present Plan for Review


### PR DESCRIPTION
# Summary

Update `communication.md`, `feedback-handling.md`, and the `resolve-comments` skill to close gaps surfaced in retro #123. The changes add an iteration-discipline subsection to the self-review pass, add a premise-verification clause to "Verify before answering" for reviewer feedback, and surface premise verification as the first step of the `resolve-comments` analysis.

# Motivation

Issue #123 collected seven violations across two root cause groups. Each group maps to a missing or incomplete rule:

- **Per-iteration self-review skipped on short replies (violations 1, 2, 3, 6, 7)** — `Self-review before submitting` required the full pass "regardless of draft length" and instructed raising priority on the most-recently-rejected axis, but did not explicitly state that short reply iterations are bound by the same pass. Five rejections in one thread, each addressing a different axis (technical accuracy, vocabulary grounding, reference-unit clarity, coined construction, scope ambiguity), produced repeated cross-axis failures because the per-iteration pass was being skipped on short drafts.
- **Skipped premise verification on reviewer feedback (violations 4, 5)** — `Verify before answering` covered prior actions, rule questions, technical facts, subagent output, and common-practice claims but did not cover verifying whether a reviewer's flagged scenario can actually occur. The `resolve-comments` skill said "do not accept suggestions uncritically" but did not surface premise verification as a distinct step, leaving room for mechanism analysis and code modification to start before the scenario was confirmed possible. A theoretically valid concern about an impossible scenario was treated as worth a fix.

# Changes

- `communication.md` "Self-review before submitting": add an `Iteration discipline` subsection. After each rejection, run the full four-step pass on the next draft; targeted edits often re-introduce issues on axes that were correct in the rejected version (rewording for vocabulary can break sentence structure, narrowing scope can lose technical accuracy). Repeated cross-axis failures in one thread indicate the per-iteration pass is being skipped, not that the rules need to expand. Short reply iterations are not exempt from the full pass.
- `feedback-handling.md` "Verify before answering": add sixth situation `Responding to a reviewer's flagged scenario`. Before analyzing mechanisms, applying a defensive fix, or accepting a reviewer's proposed change, verify whether the flagged scenario can actually occur. Check the spec, naming constraints, type system, or other invariants. A theoretically valid concern about an impossible scenario does not warrant a fix — reply with the constraint that rules the scenario out, and stop. Applies to human reviewers and automated bots.
- `skills/resolve-comments/SKILL.md` Step 2 (Analyze and Draft Response Plan): add premise verification as the first item in the per-comment list. If the scenario is impossible, draft a "No change" reply citing the constraint and stop early, before reading source code or evaluating trade-offs.

closes #123

🤖 Generated with [Claude Code](https://claude.ai/code)
