### PR TITLE
docs: detect coined Japanese compounds

### DIFF
--- a/.claude/agents/copyeditor.md
+++ b/.claude/agents/copyeditor.md
@@ -139,12 +139,47 @@ Apply to both English and Japanese prose.
   | 「ロジック」 | 「処理」「論理」 (技術文脈の固有語を除き、抽象的な利用を避ける) |
   | 「クランプ」 | 「制限する」「収める」 (CSS `clamp()` 等の固有語を除き、抽象的な利用を避ける) |
 
-- **Unnatural coined Japanese words.** Compounds that read as
-  archaic or as proper nouns in technical context.
-  - OK: `新しい名前`
-  - NG: `新名` (reads as a surname)
-  - OK: `生の値`
-  - NG: `素値` (coined contraction)
+- **Unnatural coined Japanese words.** Words and compounds
+  that are not established Japanese — coined contractions,
+  archaic surname-like readings, or compounds constructed by
+  mechanically translating each English morpheme. The shape
+  may look like Japanese but the result has no dictionary
+  entry and no established usage in technical writing.
+
+  Failure modes and examples:
+
+  - **Coined contractions / proper-noun-like compounds.**
+    Short compounds that elide natural morphemes or read as
+    surnames.
+    - OK: `新しい名前`
+    - NG: `新名` (reads as a surname)
+    - OK: `生の値`
+    - NG: `素値` (coined contraction)
+  - **Mechanical morpheme concatenation.** Compounds where
+    each morpheme is a direct gloss of one word in an obvious
+    English source phrase, joined into a noun stack without
+    particles or verbs. The translation runs at the word
+    level rather than at the concept level.
+    - OK: 「逐次計算」「即時評価」「動的解決」 (established
+      compounds with dictionary entries)
+    - OK: 「実行時に値を計算する」 (decomposed sentence)
+    - NG: 「その場計算」 (literal of "on-the-spot
+      computation"; depending on intended meaning, use
+      「逐次計算」「即時計算」「動的計算」「実行時計算」 etc.)
+    - NG: 「即興分岐生成」 (literal of "ad-hoc branch
+      generation"; decompose to 「動的に分岐を生成する」)
+    - NG: 「現位置更新」 (literal of "in-place update"; use
+      「直接更新する」 or the established loanword
+      「インプレース更新」 if it fits the surrounding style)
+    - NG: 「文脈窓」 (literal of "context window"; the
+      established term is 「コンテキストウィンドウ」)
+
+  Verification: when uncertain whether a compound is
+  established, search Japanese technical sources via
+  `WebFetch` before passing. A compound with no hits in
+  normal usage is a coinage, not a term. Replace with the
+  established compound for the intended concept, or decompose
+  into a sentence with explicit verbs and particles.
 - **Particle errors.** Subject / object marker mismatches
   (が / を / は / に / で). Read each sentence in isolation
   and confirm each particle fits the verb's argument structure.

--- a/.claude/rules/writing-style-ja.md
+++ b/.claude/rules/writing-style-ja.md
@@ -56,9 +56,10 @@ katakana should be replaced with plain Japanese.
 
 The `copyeditor` agent runs the detailed checks (literal
 katakana replacement, English-to-Japanese syntax inversion,
-mixed-construct particle correctness, half-width spacing and
-parentheses, sentence completion). The intent at the authoring
-stage is to catch the obvious cases before invoking it.
+mixed-construct particle correctness, coined Japanese
+compounds, half-width spacing and parentheses, sentence
+completion). The intent at the authoring stage is to catch
+the obvious cases before invoking it.
 
 ## Style Consistency
 


### PR DESCRIPTION
# Summary

Extend the `copyeditor` agent's "Unnatural coined Japanese words" check to cover compounds formed by mechanically translating each English morpheme into Japanese and concatenating the result (e.g. 「その場計算」 from "on-the-spot computation"), in addition to the coined contractions and proper-noun-like readings the check already covered.

# Motivation

PR #126 introduced the `copyeditor` agent with an "Unnatural coined Japanese words" check that listed `素値` (coined contraction) and `新名` (surname-like reading) as NG examples. A coinage observed during drafting — 「その場計算」 from "on-the-spot computation" — illustrates a distinct failure mode: the model glosses an English source phrase word-by-word and joins the results into a noun stack. The result has no dictionary entry and no established usage in Japanese technical writing.

The pre-existing check listed only contraction-style NG examples, so the agent had no pattern to match the morpheme-concatenation case against.

# Changes

- `.claude/agents/copyeditor.md`: restructure the "Unnatural coined Japanese words" check as a parent bullet with two named sub-bullets — `Coined contractions / proper-noun-like compounds` (the prior coverage) and `Mechanical morpheme concatenation` (the new failure mode). The new sub-bullet adds four NG examples (「その場計算」, 「即興分岐生成」, 「現位置更新」, 「文脈窓」), each paired with an established Japanese alternative or a decomposed sentence. Adds a `WebFetch` verification step: when uncertain whether a compound is established, search Japanese technical sources before passing the draft.
- `.claude/rules/writing-style-ja.md`: extend the `Vocabulary` section's summary of copyeditor-handled checks to list "coined Japanese compounds" so the author's pre-pass surfaces obvious cases before invocation.

🤖 Generated with [Claude Code](https://claude.ai/code)
