### PR TITLE
docs: collapse rule enumerations into copyeditor

### DIFF
--- a/.claude/agents/copyeditor.md
+++ b/.claude/agents/copyeditor.md
@@ -198,9 +198,37 @@ Apply to both English and Japanese prose.
   「徹底的に〜する」「全く〜ない」「絶対に〜」「断ち切る」
   「一掃する」「根絶する」. Replace with specific quantitative
   wording.
+- **Relative references.** Replace relative pointers with
+  concrete references (class name, method name, PR number,
+  commit id). Time-relative references rot as the document
+  ages.
+  - **Time-relative pointers** — 「以前」「現在」「今後」
+    「経過措置として残置」.
+    - OK: 「この処理は issue #123 の解消後に削除する」
+    - NG: 「この処理は今後削除する」
+  - **Old/new contrasts** — 「旧」「新」「新旧」.
+    - OK: 「PR #100 で導入された `FooClient` の delegate を
+      `BarClient` に切り替える」
+    - NG: 「旧 client から新 client に切り替える」
+  - **Directional references** — 「〜側」「〜方向の挙動」.
+    - OK: 「`Foo#bar` の戻り値が変わる」
+    - NG: 「`Foo` 側の挙動が変わる」
 
 **English and language-agnostic checks:**
 
+- **Intensifiers without quantitative evidence** (`very`,
+  `extremely`, `significantly`, `highly`, `incredibly`) —
+  replace with a measured indicator or delete.
+- **Meta-phrasings** (`This is important because...`, `It's
+  worth noting...`, `Crucially...`, `Notably...`) — state
+  the claim directly without the framing phrase.
+- **Vague enumeration markers** (`etc.`, `such as`, `and so
+  on`, `among others`) — list the relevant items concretely
+  or drop the marker.
+- **Hedged speculation about prior context** (`This was
+  likely introduced to...`, `Presumably...`, `It seems
+  that...`) — these invent motivation the source does not
+  state. Replace with the verified motivation or delete.
 - **Evaluative adjectives** (`thin`, `trivial`, `obvious`,
   `clean`, `brittle`, `important`, `seamless`, `robust`) —
   replace with a concrete indicator (line count, dependency

--- a/.claude/rules/document-writing.md
+++ b/.claude/rules/document-writing.md
@@ -38,22 +38,12 @@ only if the template explicitly allows it.
 
 ## Writing Style
 
-Write naturally. Avoid:
+Tone and vocabulary rules in `writing-style.md` and
+`writing-style-ja.md` apply. Documents additionally:
 
-- Bullet lists where prose flows better
-- Exaggerated or emphatic expressions:
-  - "revolutionary", "game-changing", "seamless", "robust", "cutting-edge"
-  - "very", "extremely", "significantly" (without quantitative evidence)
-  - "This is important because...", "It's worth noting...", "Crucially..."
-- Repeating information
-- Vague expressions (overuse of "etc.", "such as", "and so on")
-
-### Style Consistency
-
-When editing existing documents, match the established writing style:
-
-- **Japanese documents**: Match the formality level (敬語 vs 常体)
-  - If the document uses です/ます (polite form), continue with polite form
-  - If the document uses である/だ (plain form), continue with plain form
-- **English documents**: Match the tone and voice (formal, casual, technical)
-- Never mix styles within the same document, except in clearly demarcated sections (e.g., quoted text, appendices, or code examples)
+- Avoid bullet lists where prose flows better.
+- Match the established formality (敬語 vs 常体 for Japanese; formal,
+  casual, or technical voice for English) when editing existing
+  documents. Never mix styles within the same document, except in
+  clearly demarcated sections (quoted text, appendices, code
+  examples).

--- a/.claude/rules/writing-style-ja.md
+++ b/.claude/rules/writing-style-ja.md
@@ -2,64 +2,19 @@
 
 Apply to all Japanese prose text (documents, comments, descriptions).
 
-## Tone
-
-Avoid Japanese-specific exaggerated expressions. They overstate the
-change and weaken precise technical claims. This is the Japanese
-counterpart to `writing-style.md` "Tone".
-
-Avoid:
-
-- 「完全に〜する」「徹底的に〜する」「全く〜ない」「絶対に〜」
-- 「断ち切る」「一掃する」「根絶する」
-
-Use specific, quantitative wording instead:
-
-- OK: `フォールバックを 2 箇所削除した`
-- NG: `フォールバックを完全に断ち切った`
-
 ## Relative References
 
-Replace relative pointers with concrete references (class name, method
-name, PR number, commit id). Time-relative references rot when the
-document is read later, since "現在" and "今後" lose their anchor as
-time passes.
-
-Avoid:
-
-- 時間的相対参照: 「以前」「現在」「今後」「経過措置として残置」
-- 新旧の相対参照: 「旧」「新」「新旧」
-- 方向的な相対参照: 「〜側」「〜方向の挙動」
-
-時間的相対参照:
-
-- OK: `この処理は issue #123 の解消後に削除する`
-- NG: `この処理は今後削除する`
-
-新旧の相対参照:
-
-- OK: `PR #100 で導入された FooClient の delegate を BarClient に切り替える`
-- NG: `旧 client から新 client に切り替える`
-
-方向的な相対参照:
-
-- OK: `Foo#bar の戻り値が変わる`
-- NG: `Foo 側の挙動が変わる`
+Replace relative pointers with concrete references (class name,
+method name, PR number, commit id). Time-relative references rot
+when the document is read later. The `copyeditor` agent runs the
+detailed checks.
 
 ## Vocabulary
 
 Prefer plain Japanese over katakana / English loanwords when
-natural Japanese exists. Acceptable katakana and English terms
-are restricted to established technical proper nouns (`JSON`,
-`API`, `Pull Request`, etc.). Abstract concepts written in
-katakana should be replaced with plain Japanese.
-
-The `copyeditor` agent runs the detailed checks (literal
-katakana replacement, English-to-Japanese syntax inversion,
-mixed-construct particle correctness, coined Japanese
-compounds, half-width spacing and parentheses, sentence
-completion). The intent at the authoring stage is to catch
-the obvious cases before invoking it.
+natural Japanese exists. Established technical proper nouns
+(`JSON`, `API`, `Pull Request`) are acceptable. The `copyeditor`
+agent runs the detailed checks.
 
 ## Style Consistency
 

--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -4,37 +4,27 @@ Apply to all text output (documents, PR descriptions, commit messages, comments)
 
 ## Tone
 
-Write naturally. Avoid:
-
-- Exaggerated or emphatic expressions:
-  - "revolutionary", "game-changing", "seamless", "robust", "cutting-edge"
-  - "very", "extremely", "significantly" (without quantitative evidence)
-  - "This is important because...", "It's worth noting...", "Crucially..."
-- Repeating information
-- Vague expressions (overuse of "etc.", "such as", "and so on")
+Write naturally. Avoid intensifiers without quantitative evidence,
+meta-phrasings, vague enumeration markers, and repetition. The
+`copyeditor` agent runs the detailed checks.
 
 ## Accuracy
 
-Do not speculate about context specific to the user's project or situation:
+Do not speculate about context specific to the user's project or
+situation:
 
 - Do not invent background, motivation, or history the user has not stated
-- Do not guess intent with hedged language (e.g., "This was likely introduced to...", "Presumably...")
+- Do not guess intent with hedged language (the `copyeditor` agent
+  runs the detailed checks)
 - When project-specific context is missing and needed, always ask the user before writing
 
-General knowledge and publicly verifiable facts may be stated without qualification.
+General knowledge and publicly verifiable facts may be stated without
+qualification.
 
 ## Vocabulary
 
-Prefer plain words. Replace abstract jargon, domain-foreign
-metaphors, evaluative adjectives without concrete indicators,
-and ungrounded abstract nouns with the plainest alternative
-that carries the same meaning.
-
-The `copyeditor` agent runs the detailed checks (modifier-of
-relationships, evaluative adjective replacement, false-contrast
-framing, fact verification against source). The intent at the
-authoring stage is to catch the obvious cases before invoking
-it.
+Prefer plain words over jargon, metaphors, and abstract nouns. The
+`copyeditor` agent runs the detailed checks.
 
 ## Style Consistency
 


### PR DESCRIPTION
# Summary

Collapse the literal-match enumerations that lived in both
`.claude/rules/` and `.claude/agents/copyeditor.md` into the
copyeditor agent. The rule files keep policy plus a pointer
to the agent.

# Motivation

The rule files and the copyeditor agent each carried their
own copies of the same detail-level guidance — intensifiers,
meta-phrasings, vague enumeration markers, hedged language,
and relative-reference pointers — and `document-writing.md`
duplicated the entire Writing Style section from
`writing-style.md`. Two copies drift whenever one is updated
and the other is not.

# Changes

- Add `Relative references` to copyeditor.md's
  Japanese-specific checks (time-relative, old/new,
  directional).
- Add `Intensifiers without quantitative evidence`,
  `Meta-phrasings`, `Vague enumeration markers`, and
  `Hedged speculation about prior context` to copyeditor.md's
  English-and-language-agnostic checks.
- Collapse the Tone, Accuracy, and Vocabulary enumerations in
  `writing-style.md` to a single policy line each, pointing
  at the copyeditor agent.
- Delete the Tone section and collapse the Relative
  References / Vocabulary enumerations in
  `writing-style-ja.md`.
- Replace `document-writing.md`'s duplicated Writing Style
  section with a pointer to the shared style files.

🤖 Generated with [Claude Code](https://claude.ai/code)
