### PR TITLE
docs: widen exaggerated-expression coverage

### DIFF
--- a/.claude/agents/copyeditor.md
+++ b/.claude/agents/copyeditor.md
@@ -230,7 +230,8 @@ Apply to both English and Japanese prose.
   that...`) — these invent motivation the source does not
   state. Replace with the verified motivation or delete.
 - **Evaluative adjectives** (`thin`, `trivial`, `obvious`,
-  `clean`, `brittle`, `important`, `seamless`, `robust`) —
+  `clean`, `brittle`, `important`, `seamless`, `robust`,
+  `revolutionary`, `game-changing`, `cutting-edge`) —
   replace with a concrete indicator (line count, dependency
   count, named property) or delete.
 - **Technical contrasts** (`direct vs. indirect`, `sync vs.

--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -4,9 +4,9 @@ Apply to all text output (documents, PR descriptions, commit messages, comments)
 
 ## Tone
 
-Write naturally. Avoid intensifiers without quantitative evidence,
-meta-phrasings, vague enumeration markers, and repetition. The
-`copyeditor` agent runs the detailed checks.
+Write naturally. Avoid exaggerated expressions, meta-phrasings,
+and vague enumeration markers. The `copyeditor` agent runs the
+detailed checks.
 
 ## Accuracy
 


### PR DESCRIPTION
# Summary

Follow-up to PR #128. Widen the Tone policy in
`writing-style.md` and add three exaggerated adjectives that
existed in the prior Tone list but were never carried over to
the copyeditor agent's `Evaluative adjectives` list.

# Motivation

PR #128 review surfaced two coverage gaps in how the Tone
policy maps to the copyeditor agent. The original Tone list
in `writing-style.md` flagged five exaggerated adjectives
(`revolutionary`, `game-changing`, `seamless`, `robust`,
`cutting-edge`), but only `seamless` and `robust` were
carried over to `Evaluative adjectives`. The collapsed Tone
line then labeled the exaggerated-adjective category only as
`intensifiers`, which is narrower than the pre-PR-#128
heading `Exaggerated or emphatic expressions`.

# Changes

- Add `revolutionary`, `game-changing`, and `cutting-edge` to
  copyeditor.md's `Evaluative adjectives` list.
- Rewrite `writing-style.md` Tone line to: `Write naturally.
  Avoid exaggerated expressions, meta-phrasings, and vague
  enumeration markers. The copyeditor agent runs the detailed
  checks.` (drops `intensifiers` for the broader label, and
  drops `repetition` since the `Redundancy` section already
  owns that policy).

🤖 Generated with [Claude Code](https://claude.ai/code)
