### PR TITLE
docs: restrict copyeditor invocation inputs

### DIFF
--- a/.claude/rules/output-review.md
+++ b/.claude/rules/output-review.md
@@ -45,9 +45,24 @@ Use the `Agent` tool with `subagent_type: copyeditor`. Pass:
 
 1. The draft text verbatim.
 2. The destination (plan file, PR review reply, etc.).
-3. Any context the agent needs to verify facts: branch name,
-   referenced PR / issue numbers, file paths mentioned in the
-   draft.
+3. Fact-verification pointers the agent may need to look up
+   sources: branch name, referenced PR / issue numbers, file
+   paths mentioned in the draft. Limit this to look-up pointers
+   — nothing more.
+
+Do not pass inspection scope to the agent. The copyeditor's
+inspection categories are defined in its own spec, and narrowing
+the scope risks the agent reviewing only the listed perspectives
+and missing the rest. Do not include:
+
+- Lists of check categories ("check katakana loanwords and
+  particles") — the agent already runs all inspection
+  categories.
+- Severity ranking or priority hints ("focus on fact
+  verification") — the agent's output is already ordered by
+  severity.
+- Excerpts from `writing-style.md` / `writing-style-ja.md` —
+  the agent already incorporates those rules into its checks.
 
 Apply the agent's findings before sending the draft. If a
 finding is rejected, state the reason in your response — silent


### PR DESCRIPTION
# Summary

Tighten `output-review.md` so callers invoking the `copyeditor` agent pass only fact-verification look-up pointers, not inspection-scope hints. The agent's inspection categories live in its own spec; caller-side scope hints risk narrowing the review.

# Motivation

The previous "How to invoke" section allowed "any context the agent needs to verify facts" as a free-form third input. In practice this opened the door for callers to paste check lists, severity hints, and excerpts from `writing-style.md` / `writing-style-ja.md` into the prompt. When the prompt names specific perspectives, the agent can treat the listed perspectives as the scope of the review and skip the rest of its spec, defeating the gate.

The fix belongs on the caller side rather than the agent side: the copyeditor agent's `## Inspection categories` already defines its full review scope, and the duplicated scope on the caller side is what causes the agent to skip the rest of its spec.

# Changes

- Narrow item 3 of "How to invoke" in `.claude/rules/output-review.md` to fact-verification look-up pointers (branch, PR / issue numbers, file paths), with explicit "nothing more" wording.
- Add a prohibition block listing the three caller-side patterns that drift the review scope: check-category lists, severity / priority hints, and excerpts from `writing-style.md` / `writing-style-ja.md`.

🤖 Generated with [Claude Code](https://claude.ai/code)