### PR TITLE
docs: prefer GitHub CLI over MCP tools

### DIFF
--- a/.claude/rules/tool-usage.md
+++ b/.claude/rules/tool-usage.md
@@ -2,6 +2,12 @@
 
 Use dedicated tools instead of Bash equivalents.
 
+## GitHub CLI vs MCP
+
+When both GitHub CLI (`gh`) and MCP GitHub tools are available, always prefer GitHub CLI. Use MCP GitHub tools only when the equivalent `gh` command does not exist or cannot achieve the desired result.
+
+## Dedicated Tools vs Bash
+
 | Operation  | Dedicated tool | Bash (denied in settings.json) |
 | ---------- | -------------- | ------------------------------ |
 | Read files | Read           | `cat`                          |


### PR DESCRIPTION
# Summary

Adds a rule to `tool-usage.md` establishing GitHub CLI (`gh`) as the always-preferred tool over MCP GitHub tools when both are available. MCP tools should only be used when `gh` has no equivalent command or cannot achieve the desired result. Also adds a `## Dedicated Tools vs Bash` header to give the existing table its own section, maintaining correct document hierarchy.

# Motivation

In environments where both `gh` and MCP GitHub tools are available, there was no explicit guidance on which to prefer. Without a clear rule, the agent might choose MCP tools unnecessarily, bypassing `gh`, which is more auditable and scriptable than MCP GitHub tools, and whose use is already established in these dotfiles.

# Changes

- Added `## GitHub CLI vs MCP` section to `.claude/rules/tool-usage.md` stating that `gh` is always preferred, with MCP as a fallback only when `gh` has no equivalent command or cannot achieve the desired result.
- Added `## Dedicated Tools vs Bash` header above the existing file-operation table to maintain correct document hierarchy.
