### PR TITLE
refactor: make copyediting an explicit skill

### DIFF
--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -75,7 +75,7 @@ Before sending each draft (PR description, commit message, headings, review repl
 1. **Sentence structure** — subject / object alignment, particle choice in Japanese, grammar in English. Read each sentence as if encountering it for the first time.
 2. **Technical accuracy** — claims about behavior, scope, and history match the source. See `feedback-handling.md` "Verify before answering".
 3. **Redundancy and noise** — sections that duplicate the change list or restate self-evident information. See `writing-style.md` "Redundancy".
-4. **Vocabulary discipline** — scan for metaphors, katakana loanwords, and abstract jargon; replace with plain alternatives where one conveys the same meaning. The `copyeditor` agent runs detailed checks after this pass; catch the obvious cases here so the agent has less to find.
+4. **Vocabulary discipline** — scan for metaphors, katakana loanwords, and abstract jargon; replace with plain alternatives where one conveys the same meaning.
 
 Apply this pass regardless of draft length. Raise priority on the axis where the user pushed back most recently — repeated failures on the same axis indicate the self-review pass missed it last time.
 

--- a/.claude/rules/output-review.md
+++ b/.claude/rules/output-review.md
@@ -1,45 +1,11 @@
 # Output Review
 
-Apply when sending user-facing output that does not pass through a skill workflow's own copyeditor invocation.
+## Copyediting via `/copyedit`
 
-## Why this rule exists
+Invoke the `/copyedit` skill only when explicitly requested. Do not invoke it automatically.
 
-Skill workflows (`publish`, `commit`, `retro`, `design-doc`, `analysis-report`) invoke the `copyeditor` agent on their output before sending. Output produced outside those workflows — plan files, PR review replies, regular chat, AskUserQuestion descriptions — has no equivalent gate, and recurring vocabulary and fact-verification failures have happened in those contexts.
+Situations where copyediting is useful:
 
-## When copyeditor invocation is required
-
-Invoke the `copyeditor` agent before sending output that meets any of the following:
-
-- **Long-form paragraph output.** Roughly 200 characters or more of Japanese prose, or a comparable span of English prose.
-- **Structured text.** Output containing headings, lists, tables, or block quotes that the user will read end-to-end.
-- **Plan files.** Plans authored via `EnterPlanMode` / read by `ExitPlanMode` are user-facing deliverables. Run the copyeditor before calling `ExitPlanMode`.
-- **PR / issue / review comment bodies created outside a skill workflow.** When responding to a review thread or commenting on an issue without going through `publish` or `resolve-comments`, the body is still user-facing output and needs the same review.
-
-## When copyeditor invocation is not required
-
-- Short conversational replies (under the length threshold and no structural elements).
-- Code-only output (the diff itself, no prose).
-- Tool call arguments that are not user-prose (file paths, command flags, JSON payloads).
-- Internal Bash output the user does not read end-to-end.
-
-## How to invoke
-
-Use the `Agent` tool with `subagent_type: copyeditor`. Pass:
-
-1. The draft text verbatim.
-2. The destination (plan file, PR review reply, etc.).
-3. Fact-verification pointers the agent may need to look up sources: branch name, referenced PR / issue numbers, file paths mentioned in the draft. Limit this to look-up pointers — nothing more.
-
-Do not pass inspection scope to the agent. The copyeditor's inspection categories are defined in its own spec, and narrowing the scope risks the agent reviewing only the listed perspectives and missing the rest. Do not include:
-
-- Lists of check categories ("check katakana loanwords and particles") — the agent already runs all inspection categories.
-- Severity ranking or priority hints ("focus on fact verification") — the agent's output is already ordered by severity.
-- Excerpts from `writing-style.md` / `writing-style-ja.md` — the agent already incorporates those rules into its checks.
-
-Apply the agent's findings before sending the draft. If a finding is rejected, state the reason in your response — silent rejection of a copyeditor finding defeats the gate.
-
-## Interaction with `Self-review before submitting`
-
-`communication.md` "Self-review before submitting" runs first, as the author's pass. The copyeditor runs second, as the external pass on the same draft. They are not redundant: the self-review catches what the author can catch reading their own text; the copyeditor catches what the author missed.
-
-When the copyeditor flags an axis the self-review already covered, that is a signal the self-review pass was skipped on that axis. Treat it as a self-review failure to address in the next retro, not as a copyeditor false positive.
+- Before sending a PR description, issue body, or review comment
+- Before finalizing a design doc or plan file
+- Before creating a retro issue body

--- a/.claude/rules/writing-style-ja.md
+++ b/.claude/rules/writing-style-ja.md
@@ -4,11 +4,11 @@ Apply to all Japanese prose text (documents, comments, descriptions).
 
 ## Relative References
 
-Replace relative pointers with concrete references (class name, method name, PR number, commit id). Time-relative references rot when the document is read later. The `copyeditor` agent runs the detailed checks.
+Replace relative pointers with concrete references (class name, method name, PR number, commit id). Time-relative references rot when the document is read later.
 
 ## Vocabulary
 
-Prefer plain Japanese over katakana / English loanwords when natural Japanese exists. Established technical proper nouns (`JSON`, `API`, `Pull Request`) are acceptable. The `copyeditor` agent runs the detailed checks.
+Prefer plain Japanese over katakana / English loanwords when natural Japanese exists. Established technical proper nouns (`JSON`, `API`, `Pull Request`) are acceptable.
 
 ## Style Consistency
 

--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -4,21 +4,21 @@ Apply to all text output (documents, PR descriptions, commit messages, comments)
 
 ## Tone
 
-Write naturally. Avoid exaggerated expressions, meta-phrasings, and vague enumeration markers. The `copyeditor` agent runs the detailed checks.
+Write naturally. Avoid exaggerated expressions, meta-phrasings, and vague enumeration markers.
 
 ## Accuracy
 
 Do not speculate about context specific to the user's project or situation:
 
 - Do not invent background, motivation, or history the user has not stated
-- Do not guess intent with hedged language (the `copyeditor` agent runs the detailed checks)
+- Do not guess intent with hedged language
 - When project-specific context is missing and needed, always ask the user before writing
 
 General knowledge and publicly verifiable facts may be stated without qualification.
 
 ## Vocabulary
 
-Prefer plain words over jargon, metaphors, and abstract nouns. The `copyeditor` agent runs the detailed checks.
+Prefer plain words over jargon, metaphors, and abstract nouns.
 
 ## Style Consistency
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -53,7 +53,6 @@ Understand the changes before staging:
   - Format follows Conventional Commits
   - Body explains the rationale, not the mechanics
   If any check fails, fix the message and re-verify. Do not proceed with `git commit` until all checks pass.
-- When the body contains more than a single sentence, invoke the `copyeditor` agent on the body before running `git commit`. Use the `Agent` tool with `subagent_type: copyeditor`, pass the drafted message body and the destination "commit message body", and include the branch name, the staged file paths, and any PR / issue numbers the body references so the agent can verify facts. Apply the agent's findings; if a finding is rejected, state the reason inline.
 - When writing the message body, explain WHY the change is needed. Do not list every file or sub-change — the diff shows that. Focus on the core motivation; omit supporting changes unless they have independent rationale a reviewer needs to understand.
 - If changes fall into multiple distinct groups, create one commit per group
 - For each group: `git add <files>`, craft a commit message, then `git commit`

--- a/.claude/skills/copyedit/SKILL.md
+++ b/.claude/skills/copyedit/SKILL.md
@@ -1,22 +1,13 @@
 ---
-name: copyeditor
-description: Reviews user-facing output (Japanese and English) for factual accuracy, internal consistency, and expression naturalness before it is sent. Use before publishing any long-form text — PR descriptions, commit message bodies, issue/comment bodies, plan files, design docs, analysis reports, and any structured paragraph the user will read.
-tools: Bash, Read, WebFetch, Grep, Glob
-model: inherit
+name: copyedit
+description: Review user-facing output for factual accuracy, internal consistency, and expression naturalness before sending. Invoke explicitly when copyediting is needed.
 ---
 
-# copyeditor
+# Copyedit
 
 You are a copyeditor reviewing a draft before it reaches the user. Copyediting in publishing covers grammar, expression naturalness, fact-checking, consistency, and light rewording — the same scope applies here.
 
 You operate as a final pass on text that has already gone through the author's self-review. Your role is to catch what the author missed, not to rewrite to your preference.
-
-## Operating principles
-
-- **Do not alter technical precision.** If a claim names a specific file, line range, commit, PR number, or numeric boundary, preserve those exact values unless the verification step proves them wrong.
-- **Preserve original intent.** Identify the author's argument before suggesting changes. A suggestion that flips the argument's direction is a rewrite, not an edit.
-- **Avoid over-rewriting.** When the original wording is acceptable, leave it. Only flag items that meet one of the inspection categories below.
-- **Return "could not verify" explicitly.** When a fact cannot be checked against an available source, do not pass it silently. Mark it as unverified so the author can decide whether to remove or rephrase.
 
 ## Inputs
 
@@ -27,6 +18,13 @@ The invoking caller will supply:
 3. Optional: branch name, base branch, related issue/PR numbers, paths the draft references — anything that lets you verify the draft against an actual source.
 
 If the destination is not stated, infer it from the draft shape (commit message subject + body, PR description with `# Summary` heading, issue body with `## Violations` table, etc.) and state your inference in the output.
+
+## Operating principles
+
+- **Do not alter technical precision.** If a claim names a specific file, line range, commit, PR number, or numeric boundary, preserve those exact values unless the verification step proves them wrong.
+- **Preserve original intent.** Identify the author's argument before suggesting changes. A suggestion that flips the argument's direction is a rewrite, not an edit.
+- **Avoid over-rewriting.** When the original wording is acceptable, leave it. Only flag items that meet one of the inspection categories below.
+- **Return "could not verify" explicitly.** When a fact cannot be checked against an available source, do not pass it silently. Mark it as unverified so the author can decide whether to remove or rephrase.
 
 ## Inspection categories
 
@@ -84,7 +82,7 @@ Apply to both English and Japanese prose.
   | 「カテゴリー」 | 「分類」「区分」 |
   | 「マッピング」 | 「対応付け」 (コード内のマップデータ構造を指す場合は除く) |
   | 「ロジック」 | 「処理」「論理」 (技術文脈の固有語を除き、抽象的な利用を避ける) |
-  | 「クランプ」 | 「制限する」「収める」 (CSS `clamp()` 等の固有語を除き、抽象的な利用を避ける) |
+  | 「クランプ」 | 「制限する」「収める」 (CSS `clamp()` 等の固有語を除く) |
 
 - **Unnatural coined Japanese words.** Words and compounds that are not established Japanese — coined contractions, archaic surname-like readings, or compounds constructed by mechanically translating each English morpheme. The shape may look like Japanese but the result has no dictionary entry and no established usage in technical writing.
 
@@ -98,7 +96,7 @@ Apply to both English and Japanese prose.
   - **Mechanical morpheme concatenation.** Compounds where each morpheme is a direct gloss of one word in an obvious English source phrase, joined into a noun stack without particles or verbs. The translation runs at the word level rather than at the concept level.
     - OK: `逐次計算`、`即時評価`、`動的解決` (established compounds with dictionary entries)
     - OK: `実行時に値を計算する` (decomposed sentence)
-    - NG: `その場計算` (literal of "on-the-spot computation"; depending on intended meaning, use `逐次計算`、`即時計算`、`動的計算`、`実行時計算` etc.)
+    - NG: `その場計算` (literal of "on-the-spot computation"; use `逐次計算`、`即時計算`、`動的計算`、`実行時計算` etc.)
     - NG: `即興分岐生成` (literal of "ad-hoc branch generation"; decompose to `動的に分岐を生成する`)
     - NG: `現位置更新` (literal of "in-place update"; use `直接更新する` or the established loanword `インプレース更新` if it fits the surrounding style)
     - NG: `文脈窓` (literal of "context window"; the established term is `コンテキストウィンドウ`)
@@ -226,8 +224,7 @@ Return the review as a markdown document with the following sections:
 
 ### Category: <inspection category from above>
 
-- **Location**: <quote of the offending span, or section / line
-  reference>
+- **Location**: <quote of the offending span, or section / line reference>
 - **Issue**: <one-sentence explanation>
 - **Suggestion**: <proposed correction>
 - **Source**: <verified evidence, if applicable>
@@ -236,8 +233,7 @@ Return the review as a markdown document with the following sections:
 
 ## Summary
 
-<one paragraph: overall judgment — ready to send, ready with
-minor edits, or needs rework>
+<one paragraph: overall judgment — ready to send, ready with minor edits, or needs rework>
 ```
 
 Order findings from highest to lowest severity:

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -71,8 +71,6 @@ gh pr list --head <current-branch> --limit 1
 
 When updating, rewrite the description against the final diff. The description is for reviewers of the final code, not a work log of development iterations. Do not append changelogs (e.g., "Fixed X in this update", "Previously Y was broken").
 
-Before sending the updated body to `gh pr edit` (or the GitHub MCP `update_pull_request` tool), invoke the `copyeditor` agent on the draft. See "Copyedit before submitting" below.
-
 **If no PR exists:**
 
 1. Choose title:
@@ -106,8 +104,6 @@ Before sending the updated body to `gh pr edit` (or the GitHub MCP `update_pull_
 
 **IMPORTANT**: Always read the selected template file before creating the PR description.
 
-Before sending the body to `gh pr create` (or the GitHub MCP `create_pull_request` tool), invoke the `copyeditor` agent on the draft. See "Copyedit before submitting" below.
-
 When passing the body to `gh pr create` or `gh pr edit`, use a HEREDOC inline within the command. Do not stage the body to a local file (e.g. `/tmp/pr-body.md`) and pass it via `--body-file <path>`.
 
 OK:
@@ -122,23 +118,7 @@ NG: `Write /tmp/pr-body.md`, then `gh pr create --title "..." --body-file /tmp/p
 
 The user reviews tool calls before they run. Inline HEREDOC puts the body in the call so they see it before approving. A separate Write step bypasses this — once the file exists, the follow-up `gh` call sends content the user has not yet reviewed.
 
-## 4. Copyedit before submitting
-
-Before **every** `gh pr create` or `gh pr edit` call — including iterative edits during review cycles — invoke the `copyeditor` agent on the drafted PR body. Skipping even one cycle allows vocabulary errors introduced in that cycle to go undetected.
-
-**Per-cycle invocation rule**: each time the PR description changes for any reason (reviewer feedback, terminology shift, scope update), run the copyeditor before the next `gh pr edit` call. There is no threshold below which an edit is "too small to copyedit" — the risk of re-introducing a previously-caught term is highest in small, incremental edits.
-
-Use the `Agent` tool with `subagent_type: copyeditor`. Pass:
-
-1. The draft body verbatim.
-2. The destination: "PR description" plus the target PR number when editing.
-3. Context for fact verification: current branch, base branch, referenced PR / issue numbers, file paths mentioned in the draft.
-
-Apply the agent's findings before submitting. If a finding is rejected, state the reason inline — silent rejection defeats the gate.
-
-For findings marked "could not verify", either supply the missing source to the agent and re-run, or rephrase the claim to remove the unverifiable assertion.
-
-## 5. Final Output
+## 4. Final Output
 
 - Display the PR URL
 - Show the current commit history relative to the default branch

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -62,19 +62,7 @@ The user reviews the plan and may:
 
 Do not proceed beyond Step 4 until the user approves the plan.
 
-## 5. Copyedit before submitting
-
-Before creating the issue, invoke the `copyeditor` agent on the approved issue body.
-
-Use the `Agent` tool with `subagent_type: copyeditor`. Pass:
-
-1. The approved issue body verbatim (violations table, root causes, countermeasures).
-2. The destination: "GitHub issue body on yusuke-suzuki/dotfiles".
-3. Context for fact verification: the rule and skill file paths the body cites, and any referenced PR / issue numbers.
-
-Apply the agent's findings before issue creation. If a finding is rejected, state the reason inline.
-
-## 6. Create GitHub Issue
+## 5. Create GitHub Issue
 
 Create an issue on the dotfiles repository.
 


### PR DESCRIPTION
# Summary

The `copyeditor` agent was invoked automatically on any output exceeding 200 Japanese characters or containing structural elements (headings, lists, tables). This made routine replies slow and token-expensive, since each invocation launched a full subagent running all 8 inspection categories with file and PR verification.

# Motivation

Automatic invocation on length/structure thresholds is too broad. Copyediting is valuable before publishing artifacts (PR descriptions, issue bodies, design docs), but not for every conversational reply.

# Changes

- Add `skills/copyedit/SKILL.md` with the full inspection logic (migrated from `agents/copyeditor.md`)
- Remove `agents/copyeditor.md`
- Rewrite `rules/output-review.md`: replace automatic-invocation rules with a single directive to use `/copyedit` explicitly
- Remove copyeditor invocation from `skills/commit/SKILL.md`, `skills/publish/SKILL.md`, and `skills/retro/SKILL.md`
- Remove copyeditor references from `rules/communication.md`, `rules/writing-style.md`, and `rules/writing-style-ja.md`

🤖 Generated with [Claude Code](https://claude.ai/code)
