### PR TITLE
docs: add decision and shell safety rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -120,6 +120,33 @@ test-only responsibilities. Inheriting that combination
 propagates an SRP violation into the new code. See
 `Technical Decision Heuristics → SRP`.
 
+### Structural decisions
+
+For data-model and boundary decisions — where data lives, which
+table or module owns a concern, the shape of a schema — design
+greenfield-first: derive the structure the domain calls for
+while ignoring the current implementation, then subtract the
+migration cost from the current state. The current state is an
+input to cost, never a justification for structure. "The
+codebase already does X" describes the starting point; it
+cannot justify extending X.
+
+This procedure applies whether or not any precedent is
+consciously cited. The two rules above fire only when a
+citation is recognized; silent pattern-matching — absorbing
+the surrounding structure without noticing that a citation is
+being made — is the failure mode this one exists to catch.
+
+### Constraint verification
+
+Before a constraint may decide an outcome, trace it to the
+place where it binds. A vocabulary, name, or interface "used
+elsewhere" constrains the current decision only if the
+artifact being designed is actually consumed there — verify
+the reference path, not the resemblance. A constraint that
+cannot be traced to a binding site is not a constraint, and
+must not act as a tiebreaker, much less a driver.
+
 ## Technical Decision Heuristics
 
 Apply these heuristics when designing or evaluating an

--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -54,7 +54,9 @@ Mechanically removing or replacing the questioned word without first stating the
 
 ## Renames and structural changes
 
-For renames, file moves, and type reorganizations, present at least three candidates with a short trade-off table on the first proposal, not only after rejection. Naming and structural decisions are reject-prone because the user often has a stronger opinion than the proposer and small wording shifts produce large readability differences. Adopting a single in-mind candidate without comparison is the failure mode this rule prevents.
+For renames, file moves, type reorganizations, and data-model decisions — storage placement, table ownership, schema shape — present at least three candidates with a short trade-off table on the first proposal, not only after rejection. Naming and structural decisions are reject-prone because the user often has a stronger opinion than the proposer and small wording shifts produce large readability differences. Adopting a single in-mind candidate without comparison is the failure mode this rule prevents.
+
+A structural choice that emerges mid-implementation is still a first proposal: the comparison accompanies the proposal, not the defense after a challenge.
 
 ## Reply length to PR / review comments
 

--- a/.claude/rules/feedback-handling.md
+++ b/.claude/rules/feedback-handling.md
@@ -20,6 +20,7 @@ When responding from your own knowledge or reconstruction, verify against the ac
 2. **Answering questions about a rule, config, or spec** — read the relevant file first. Do not paraphrase from memory when the source is accessible.
 3. **Carrying subagent output into a deliverable** — when incorporating Plan / Explore agent reports into a PR description, commit message, or code, re-verify the technical claims against the source. Subagent output is unverified until you check it.
 4. **Responding to a reviewer's flagged scenario** — before analyzing mechanisms, applying a defensive fix, or accepting a reviewer's proposed change, verify whether the flagged scenario can actually occur. Check the spec, naming constraints, type system, or other invariants that may make the scenario impossible. A theoretically valid concern about an impossible scenario does not warrant a fix — reply with the constraint that rules the scenario out, and stop. This applies equally to human reviewers and automated bots.
+5. **Reporting the status of asynchronous work** — before stating that a background agent, job, or task is running, pending, or finished, check the task registry; do not answer from the memory of having launched it. After a user interrupt, re-verify which in-flight operations actually survived before referencing any of them — an interrupt can cancel a launch that appeared to succeed.
 
 ## Suppress test execution during design discussions
 

--- a/.claude/rules/tool-usage.md
+++ b/.claude/rules/tool-usage.md
@@ -35,3 +35,23 @@ printf '...' > /tmp/body.md && gh api ... --input /tmp/body.md
 ```
 
 Heredoc keeps the published artifact and the tool-call record aligned. Temp files hide the body from the tool call and force the user to open another file to audit what was sent. This applies to any CLI body, not just to the `publish` skill.
+
+## Destructive commands and exit status
+
+A pipeline's exit status is the last command's, so `fallible-step | grep | tail` reports the filter's success and hides the fallible step's failure. Chaining a destructive follow-up onto such a pipeline with `&&` lets the destruction run on top of an unnoticed failure.
+
+NG — the rollback's failure is masked and the delete runs anyway:
+
+```bash
+rails db:rollback | grep -v noise | tail -3 && rm db/migrate/x.rb
+```
+
+OK — run the fallible step alone, confirm its outcome from the output, then run the destructive step in a separate call:
+
+```bash
+rails db:rollback
+# confirm "reverted" in the output, then:
+rm db/migrate/x.rb
+```
+
+Destructive or state-changing commands (`rm`, `git rm`, `git reset`, `git clean`, `DROP` / `DELETE`, overwriting a file) never belong on the right side of `&&` after a pipeline.


### PR DESCRIPTION
# Summary

Implements the five countermeasures from #137. Two new subsections in `CLAUDE.md` govern how structural decisions are made, and three rule files gain clauses covering data-model proposals, asynchronous status reporting, and destructive shell commands.

# Motivation

A recent design session surfaced four recurring failure modes: structural decisions anchored to the current codebase instead of the domain, a naming decision driven by a constraint that never actually binds, a cancelled background agent reported as running, and a destructive delete chained behind a pipeline that masked a failure. Half of them violated rules that already exist but fire only when a precedent is consciously cited, so the fixes target the trigger conditions as much as the content.

# Changes

- `CLAUDE.md`: add "Structural decisions" — data-model and boundary decisions are designed greenfield-first; the current state informs migration cost only and cannot justify structure
- `CLAUDE.md`: add "Constraint verification" — a constraint must be traced to the place where it binds before it may decide an outcome
- `rules/communication.md`: extend "Renames and structural changes" to data-model decisions, and require the candidate comparison at first proposal even when the choice emerges mid-implementation
- `rules/feedback-handling.md`: extend "Verify before answering" to asynchronous task status, including re-verifying what survived after a user interrupt
- `rules/tool-usage.md`: add "Destructive commands and exit status" — a destructive command never follows a pipeline whose exit status masks failure

Closes #137

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRLFdcj3ts6tamzwHWHkhe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified engineering guidance for structural and data-model decisions.
  * Added requirements to verify constraints through traceable references.
  * Expanded communication guidance for proposing structural changes and comparing trade-offs.
  * Added verification steps for reporting asynchronous task status.
  * Documented safer handling of destructive commands and pipeline failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->