### PR TITLE
fix: reorder resolve-comments to push before reply

### DIFF
--- a/.claude/skills/resolve-comments/SKILL.md
+++ b/.claude/skills/resolve-comments/SKILL.md
@@ -14,7 +14,7 @@ Identify the PR for the current branch (`gh pr view --json number,headRepository
 
 Both return paginated results — follow the `pageInfo` cursors while `hasNextPage` so no thread or comment is missed.
 
-Display unresolved threads: author, path, line, diff hunk, body.
+Exclude unresolved threads whose last comment is the current user's own reply (`gh api /user` or MCP `get_me` for the login) — they are awaiting the reviewer's response and re-enter scope only when a newer comment arrives. Display the remaining unresolved threads: author, path, line, diff hunk, body.
 
 ## 2. Analyze
 
@@ -28,15 +28,21 @@ For each unresolved comment:
 
 Enter plan mode (EnterPlanMode) and write the per-comment plan — quoted comment, path/line, analysis, recommended action — in the user's response language. Present via ExitPlanMode and do not proceed until approved.
 
-## 4. Execute
+## 4. Fix and push
 
-Reply on every unresolved thread (one reply, posted on the thread's last comment) to keep an audit trail, regardless of author (human or bot), matching the original comment's language. For fixes, make the change and reply briefly ("Done").
+Apply the approved fixes, then commit and push before posting any reply — invoke `/fixup` (or `/commit` for an independent change), then `/publish`. A reply posted while the fix exists only locally cannot be verified: review bots such as coderabbitai respond that they cannot confirm the fix.
 
-Per thread, reply first, then resolve — never in parallel, and never resolve if the reply failed:
+Skip this step when every action is "No change".
+
+## 5. Reply and resolve
+
+Reply on every unresolved thread (one reply, posted on the thread's last comment) to keep an audit trail, regardless of author (human or bot), matching the original comment's language. For fixes, reference the pushed commit id.
 
 1. **Reply** to the last comment's `databaseId`: `gh api -X POST /repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -f body="..."`, or MCP `add_reply_to_pull_request_comment`.
-2. **Resolve**: GraphQL mutation `resolveReviewThread(input: {threadId: ...})`, or MCP `pull_request_review_write` with `method: "resolve_thread"`.
+2. **Resolve**: GraphQL mutation `resolveReviewThread(input: {threadId: ...})`, or MCP `pull_request_review_write` with `method: "resolve_thread"`. Reply first, then resolve — never in parallel, and never resolve if the reply failed.
 
-## 5. Summary
+Exception — do not resolve a thread where a fix was pushed and the author of the thread's root (first) comment is a review bot that verifies fixes and resolves its own threads (e.g. coderabbitai) — later replies by other authors do not change this classification. The bot's resolution is its confirmation that the pushed commit addresses the comment, and resolving manually pre-empts that verification. "No change" threads have nothing for the bot to verify, so resolve them manually as usual.
 
-List what was fixed and what was resolved without changes; suggest next steps (`/fixup`, `/publish`).
+## 6. Summary
+
+List what was fixed and what was resolved without changes. Note threads left unresolved pending a review bot's verification; if the bot later replies that the issue persists, treat that as a new unresolved comment.


### PR DESCRIPTION
# Summary

Restructure the `resolve-comments` skill so that fix commits are pushed before any thread reply is posted, and so that threads owned by self-resolving review bots are left for the bot to resolve.

# Motivation

Review bots that verify fixes (e.g. coderabbitai) cannot confirm a fix that exists only locally, and reply that verification failed when a thread is answered before the commit reaches the remote. The same bots resolve their own threads once the pushed fix is verified, so resolving manually pre-empts that confirmation signal.

# Changes

- Split the former "Execute" step into "Fix and push" and "Reply and resolve": approved fixes are committed and pushed (`/fixup` or `/commit`, then `/publish`) before any reply is posted, and replies reference the pushed commit id.
- Skip manual resolution for fix threads whose root comment is authored by a review bot that verifies fixes and resolves its own threads; "No change" threads are still resolved manually after the reply.
- Exclude unresolved threads whose last comment is the current user's own reply from processing until a newer comment arrives, so a rerun does not post duplicate replies while a fix awaits bot verification.
- Update the summary step to report threads left unresolved pending bot verification, and drop the `/fixup` / `/publish` next-step suggestions now that pushing happens inside the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATektgjQXVkJjqaNA8aG9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATektgjQXVkJjqaNA8aG9N)_



## Summary by CodeRabbit

* **Documentation**
  * Clarified the review comment resolution workflow.
  * Approved fixes are now completed and published before related replies are sent.
  * Replies provide clearer details about applied fixes and their associated commits.
  * Review comments are resolved according to their outcome, with automated verification allowed where applicable.
  * Summaries now distinguish completed fixes, no-change decisions, and items awaiting verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the review comment resolution workflow.
  * Approved fixes are now completed and published before related replies are sent.
  * Replies provide clearer details about applied fixes and their associated commits.
  * Review comments are resolved according to their outcome, with automated verification allowed where applicable.
  * Summaries now distinguish completed fixes, no-change decisions, and items awaiting verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->