### PR TITLE
fix: drop thread resolution from resolve-comments

### DIFF
--- a/.claude/skills/address-comments/SKILL.md
+++ b/.claude/skills/address-comments/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: resolve-comments
-description: Resolve PR review comments
+name: address-comments
+description: Address PR review comments — analyze, fix, push, and reply
 ---
 
-# Resolve Comments
+# Address Comments
 
 ## 1. Fetch threads
 

--- a/.claude/skills/resolve-comments/SKILL.md
+++ b/.claude/skills/resolve-comments/SKILL.md
@@ -26,7 +26,7 @@ For each unresolved comment:
 
 ## 3. Plan approval
 
-Enter plan mode (EnterPlanMode) and write the per-comment plan — quoted comment, path/line, analysis, recommended action — in the user's response language. Present via ExitPlanMode and do not proceed until approved.
+Enter plan mode (EnterPlanMode) and write the per-comment plan — quoted comment, path/line, analysis, recommended action — in the user's response language. Present via ExitPlanMode and do not proceed until approved. Once approved, execute steps 4-6 in a single pass — do not re-enter plan mode or revise the approved actions.
 
 ## 4. Fix and push
 
@@ -34,15 +34,12 @@ Apply the approved fixes, then commit and push before posting any reply — invo
 
 Skip this step when every action is "No change".
 
-## 5. Reply and resolve
+## 5. Reply
 
-Reply on every unresolved thread (one reply, posted on the thread's last comment) to keep an audit trail, regardless of author (human or bot), matching the original comment's language. For fixes, reference the pushed commit id.
+Reply on every thread selected in step 1 (one reply, posted on the thread's last comment) to keep an audit trail, regardless of author (human or bot), matching the original comment's language. For fixes, reference the pushed commit id. Post the reply to the last comment's `databaseId`: `gh api -X POST /repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -f body="..."`, or MCP `add_reply_to_pull_request_comment`.
 
-1. **Reply** to the last comment's `databaseId`: `gh api -X POST /repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -f body="..."`, or MCP `add_reply_to_pull_request_comment`.
-2. **Resolve**: GraphQL mutation `resolveReviewThread(input: {threadId: ...})`, or MCP `pull_request_review_write` with `method: "resolve_thread"`. Reply first, then resolve — never in parallel, and never resolve if the reply failed.
-
-Exception — do not resolve a thread where a fix was pushed and the author of the thread's root (first) comment is a review bot that verifies fixes and resolves its own threads (e.g. coderabbitai) — later replies by other authors do not change this classification. The bot's resolution is its confirmation that the pushed commit addresses the comment, and resolving manually pre-empts that verification. "No change" threads have nothing for the bot to verify, so resolve them manually as usual.
+Do not resolve threads: review bots that verify fixes (e.g. coderabbitai) resolve their own threads once the pushed fix is verified, and all other threads are resolved manually outside this skill.
 
 ## 6. Summary
 
-List what was fixed and what was resolved without changes. Note threads left unresolved pending a review bot's verification; if the bot later replies that the issue persists, treat that as a new unresolved comment.
+List what was fixed and what was replied without changes. Threads stay unresolved until a review bot verifies the fix or someone resolves them manually; if a bot replies that the issue persists, treat that as a new unresolved comment.


### PR DESCRIPTION
# Summary

Remove thread resolution from the review-comment skill and rename it from `resolve-comments` to `address-comments` to match its narrowed scope: analyze comments, fix, push, and reply.

# Motivation

Resolving threads inside the skill overlaps with verifier bots such as coderabbitai, which resolve their own threads after confirming the pushed fix, and with manual resolution by reviewers. The author-based branching this required was the most error-prone part of the workflow. Separately, a second planning pass within one session rewrote actions that had already been approved.

# Changes

- Drop the resolve step and the root-comment-author exception from the workflow; the skill now ends at replying, and states that verifier bots resolve their own threads while all other threads are resolved manually outside the skill.
- Scope step 5 replies to the threads selected in step 1, so a rerun does not reply again to threads already awaiting a response.
- Forbid re-entering plan mode after approval: steps 4-6 run in a single pass without revising the approved actions.
- Rewrite the summary step around threads staying unresolved until bot verification or manual resolution.
- Rename the skill directory, `name`, `description`, and heading to `address-comments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATektgjQXVkJjqaNA8aG9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATektgjQXVkJjqaNA8aG9N)_



## Summary by CodeRabbit

* **Documentation**
  * Updated the comment-addressing workflow documentation and naming.
  * Clarified that execution requires approval before proceeding.
  * Specified that replies reference the pushed commit, while thread resolution remains a separate step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed and updated the comment-addressing workflow documentation.
  * Clarified that approval is required before execution continues.
  * Specified that replies are posted to selected unresolved threads without resolving them.
  * Documented that fixes reference the pushed commit, while thread resolution remains a separate bot or manual step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->