### PR TITLE
feat: apply textlint to committed Japanese text

### DIFF
--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -1,7 +1,7 @@
 # Writing Style
 
 - In Japanese prose, prefer plain Japanese over katakana loanwords when a natural equivalent exists, put half-width spaces around alphanumerics/code spans/links, and use half-width parentheses `()`.
-- Before publishing Japanese prose (PR description, issue body, review comment, document), run the `textlint` skill's auto-fix on the draft and review what it cannot fix.
+- Before publishing Japanese prose (PR description, issue body, review comment, document) and before committing changes that add or edit Japanese text (code comments, docstrings, test case titles, documents), run the `textlint` skill's auto-fix and review what it cannot fix.
 - Replace relative references (「以前」「今後」, old/new contrasts) with concrete ones (class name, method name, PR number, commit id). Do not invent background or motivation the user has not stated.
 - Hard-wrap only fixed-width destinations (commit messages at 72 columns, code comments) — never Markdown paragraphs.
 - End generated documents and PR descriptions with this signature (after any template's closing line):

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -21,6 +21,7 @@ Never commit to the default branch.
 ## 3. Commit
 
 - Group changes by semantic intent — one logical change per commit; create one commit per group.
+- If the diff adds or edits Japanese text (code comments, docstrings, test case titles, documents), run the `textlint` skill on it before committing.
 - Never stage files containing secrets (.env, credentials, private keys).
 - Verify the drafted message against `commit-message.md` (subject ≤ 50 characters, English, Conventional Commits, body explains why) before running `git commit`.
 - Do not use past `git log` messages as a style guide, and never use `--fixup` or `--amend` here — `/fixup` owns those.

--- a/.claude/skills/textlint/SKILL.md
+++ b/.claude/skills/textlint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: textlint
-description: Auto-format Japanese prose with textlint — katakana loanword replacement, half-width spacing and parentheses, ja-technical-writing rules. Use on Japanese drafts (PR descriptions, issue bodies, documents) before sending, or when asked to lint/format Japanese text.
+description: Auto-format Japanese prose with textlint — katakana loanword replacement, half-width spacing and parentheses, ja-technical-writing rules. Use on any Japanese text before it is published or committed — drafts (PR descriptions, issue bodies, review replies, documents) and Japanese text in source files (code comments, docstrings, test case titles) — or when asked to lint/format Japanese text.
 ---
 
 # Textlint
@@ -17,3 +17,11 @@ Dependencies run via `npx` (pinned in `lint.sh`); the first run downloads them i
 Rules live in `.textlintrc.json` (preset-ja-technical-writing, preset-ai-writing, preset-ja-spacing, no-mixed-zenkaku-and-hankaku-alphabet) and `prh.yml` (katakana loanwords with established plain-Japanese equivalents, full-width parentheses). Context-dependent loanwords (ロジック, マッピング, クランプ, ラッパー) are intentionally absent from the dictionary — replace them yourself when no established technical term is intended.
 
 After `--fix`, review the remaining report: some rules (particle errors, sentence style) are detect-only and need manual edits.
+
+## Japanese text embedded in source files
+
+textlint parses only `.md` and `.txt`; running `lint.sh` on a source file (`.ts`, `.rb`, …) is a silent no-op. Extract the Japanese fragments (code comments, docstrings, test case titles) into a scratch `.txt` file — one fragment per block, blocks separated by blank lines, keeping the original line breaks of multiline comments — run `lint.sh --fix` on it, then edit each fixed fragment back into its place in the source.
+
+`ja-no-mixed-period` reports lines that do not end with 。 but never appends one on `--fix` — ignore those reports for comments and test case titles the surrounding code writes without 句点, and for hard-wrapped lines that break mid-sentence.
+
+Out of scope: string literals whose exact value affects behavior or recorded data (assertion expectations, API response fixtures, seeds).


### PR DESCRIPTION
# Summary

Expand the textlint skill so it applies to Japanese text entering git commits — code comments, docstrings, and test case titles — in addition to prose published to GitHub.

# Motivation

The skill triggered only for published drafts (PR descriptions, issue bodies, review replies), so Japanese text committed inside source files went unlinted.

# Changes

- Extend the textlint skill trigger to cover Japanese text in files being committed
- Document the workflow for source files: textlint parses only `.md`/`.txt` and silently skips other extensions, so fragments are extracted to a scratch `.txt` file — one fragment per block, blocks separated by blank lines, keeping the original line breaks of multiline comments — fixed, and edited back into place; `ja-no-mixed-period` reports lines without 。 but `--fix` never appends one, so those reports are safe to ignore for titles, comment fragments, and hard-wrapped lines
- Scope out string literals whose exact value affects behavior or recorded data (assertion expectations, API response fixtures, seeds)
- Add a textlint step to the `/commit` skill so committed Japanese text is checked without an explicit instruction
- Require the auto-fix in `writing-style.md` before committing changes that add or edit Japanese text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xdzp8DRJnf2KhmmtRC4p8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xdzp8DRJnf2KhmmtRC4p8d)_



## Summary by CodeRabbit

* **Documentation**
  * Updated Japanese writing guidance to include comments, docstrings, test titles, and other source text.
  * Added instructions to run automatic text checks before committing Japanese text changes.
  * Clarified handling of text extracted from source files and behavior-sensitive strings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Japanese writing guidance to include comments, docstrings, test titles, and other source text.
  * Added instructions to run automatic text checks before committing Japanese text changes.
  * Clarified handling of text extracted from source files and behavior-sensitive strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->