### PR TITLE
fix: drop signature rule duplicated by default

### DIFF
--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -4,8 +4,3 @@
 - Before publishing Japanese prose (PR description, issue body, review comment, document) and before committing changes that add or edit Japanese text (code comments, docstrings, test case titles, documents), run the `textlint` skill's auto-fix and review what it cannot fix.
 - Replace relative references (「以前」「今後」, old/new contrasts) with concrete ones (class name, method name, PR number, commit id). Do not invent background or motivation the user has not stated.
 - Hard-wrap only fixed-width destinations (commit messages at 72 columns, code comments) — never Markdown paragraphs.
-- End generated documents and PR descriptions with this signature (after any template's closing line):
-
-  ```text
-  🤖 Generated with [Claude Code](https://claude.ai/code)
-  ```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,13 @@
 # Summary
 
-Brief description (2-3 sentences)
+<!-- Brief description (2-3 sentences) -->
 
 # Motivation
 
-Why are these changes needed?
+<!-- Why are these changes needed? -->
 
 # Changes
 
-- Key changes (what, not how)
+<!-- - Key changes (what, not how) -->
 
 <!-- Add additional sections below as needed (e.g., Testing) -->


### PR DESCRIPTION
# Summary

Remove the signature requirement from `rules/writing-style.md` and hide the PR template's placeholder text in HTML comments.

# Motivation

Claude Code appends its own attribution footer to PR descriptions and GitHub posts, so the signature the rule required showed up as a duplicated "Generated with" / "Generated by" pair in every description. Separately, the template's visible placeholder text renders in the description when a section is left unfilled; the same fix is already applied to the qoodish and qoodish-web templates.

# Changes

- Delete the signature bullet from `.claude/rules/writing-style.md`
- Wrap the placeholder text in `.github/pull_request_template.md` in HTML comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFoaBWyEVz7xfHNaEGDiA3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFoaBWyEVz7xfHNaEGDiA3)_