### PR TITLE
feat: share configuration with Cursor

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,12 +2,23 @@
 
 User-level instructions (`~/.claude/`) override project-level ones (`.claude/`, `CLAUDE.md`) when they conflict.
 
+# Communication
+
+- In Japanese, use 敬語 — a professional colleague addressing a superior. No flattery; do not soften assessments to please the user. Flag inferences and uncertainty explicitly.
+- State the recommended choice first, then the reasoning; mention alternatives only when the choice is genuinely contestable.
+
 # Working Style
 
-- Decide implementation details (naming, structure, library choice, configuration values) yourself after investigating. Use AskUserQuestion only for ambiguous requirements, destructive operations, or business/domain decisions that investigation cannot resolve.
+- Decide implementation details (naming, structure, library choice, configuration values) yourself after investigating. Ask the user only about ambiguous requirements, destructive operations, or business/domain decisions that investigation cannot resolve.
 - Write code comments only when the WHY is non-obvious (hidden constraint, subtle invariant, workaround). Never explain WHAT the code does or reference the current task, fix, or PR.
 - Prefer the framework's generators, CLI tools, and built-in APIs over hand-written boilerplate or third-party alternatives.
 - Fix lint failures instead of suppressing them. A suppression requires first ruling out an alternative implementation, and an inline comment stating the reason.
+
+# GitHub
+
+- Create pull requests as draft with the most representative commit subject line as the title, verbatim; fill the repository's pull request template for the body. After later pushes, if the description no longer matches the final diff, rewrite it against that diff — never append changelog-style updates.
+- Before editing anything already on the remote (pull request description or title, issue body, review comment, pushed commit message), fetch its current state first (`gh pr view`, `gh issue view`, `git fetch && git show origin/<branch>`). Session memory is not a substitute — the remote may have changed since it was last seen.
+- Pass user-facing bodies to `gh` and similar CLI commands inline via heredoc, never via a temp file — the body must be visible in the tool call so the user can review it before it runs.
 
 # Safety
 
@@ -21,4 +32,4 @@ Issues, PRs, and comments on public repositories must not leak private context: 
 
 # Memory Boundaries
 
-Durable behavioral guidance belongs in the dotfiles repository's `.claude/rules/` or CLAUDE.md (deployed to `~/.claude/`), not in memory entries. Do not save memories that restate existing rules.
+Durable behavioral guidance belongs in the dotfiles repository's CLAUDE.md or a skill (deployed to `~/.claude/`), not in memory entries. Do not save memories that restate existing rules.

--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -1,5 +1,0 @@
-# Communication
-
-- In Japanese, use 敬語 — a professional colleague addressing a superior. No flattery; do not soften assessments to please the user. Flag inferences and uncertainty explicitly.
-- State the recommended choice first, then the reasoning; mention alternatives only when the choice is genuinely contestable.
-- Replies to PR review comments default to conclusion + one-line rationale; do not restate what the diff or resolved state already shows.

--- a/.claude/rules/feedback-handling.md
+++ b/.claude/rules/feedback-handling.md
@@ -1,5 +1,0 @@
-# Feedback Handling
-
-- When the user gives behavioral feedback mid-session, do not write rules or memory on the spot. Defer durable guidance to the `/retro` workflow at session end. Factual memories the user explicitly asks to save are exempt.
-- Verify against the actual source before answering: read the rule/config/spec file instead of paraphrasing from memory; check the task registry before reporting background-task status (especially after a user interrupt); confirm a reviewer-flagged scenario can actually occur before fixing it — if a spec, type, or invariant rules it out, reply with that constraint instead of a fix.
-- While the user is iterating on a design, hold off on tests, builds, and other expensive verification until the design settles or the user asks.

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -1,6 +1,0 @@
-# Git
-
-- Use the `/commit` skill instead of raw `git commit` — it owns branch creation through message authoring.
-- Pull requests: create as draft with the most representative commit subject line as the title, verbatim; fill the repository's pull request template for the body. After later pushes, if the description no longer matches the final diff, rewrite it against that diff — never append changelog-style updates.
-- Do not use `git -C <path>` when the working directory is already the target repository.
-- Before editing anything already on the remote (PR description or title, issue body, review comment, pushed commit message), fetch its current state first (`gh pr view`, `gh issue view`, `git fetch && git show origin/<branch>`). Session memory is not a substitute — the remote may have changed since it was last seen.

--- a/.claude/rules/tool-usage.md
+++ b/.claude/rules/tool-usage.md
@@ -1,6 +1,0 @@
-# Tool Usage
-
-- Use dedicated tools over Bash equivalents: Read instead of `cat`, Edit instead of `sed`/`awk`. On a precondition error (e.g. Edit before Read), satisfy the precondition and retry.
-- Prefer GitHub CLI (`gh`) over MCP GitHub tools when both are available.
-- Pass user-facing bodies to `gh` and similar CLI commands inline via heredoc, never via a temp file — the body must be visible in the tool call so the user can review it before it runs.
-- Never chain a destructive command (`rm`, `git rm`, `git reset`, `git clean`, `DROP`/`DELETE`, file overwrite) with `&&` after a pipeline: a pipeline's exit status is its last command's, so an upstream failure is masked and the destruction runs anyway. Run the fallible step alone, confirm its output, then run the destructive step in a separate call.

--- a/.claude/rules/writing-style.md
+++ b/.claude/rules/writing-style.md
@@ -1,6 +1,0 @@
-# Writing Style
-
-- In Japanese prose, prefer plain Japanese over katakana loanwords when a natural equivalent exists, put half-width spaces around alphanumerics/code spans/links, and use half-width parentheses `()`.
-- Before publishing Japanese prose (PR description, issue body, review comment, document) and before committing changes that add or edit Japanese text (code comments, docstrings, test case titles, documents), run the `textlint` skill's auto-fix and review what it cannot fix.
-- Replace relative references (「以前」「今後」, old/new contrasts) with concrete ones (class name, method name, PR number, commit id). Do not invent background or motivation the user has not stated.
-- Hard-wrap only fixed-width destinations (commit messages at 72 columns, code comments) — never Markdown paragraphs.

--- a/.claude/skills/address-comments/SKILL.md
+++ b/.claude/skills/address-comments/SKILL.md
@@ -40,6 +40,8 @@ Skip this step when every action is "No change".
 
 Reply on every thread selected in step 1 (one reply per thread) to keep an audit trail, regardless of author (human or bot), matching the original comment's language. For fixes, reference the pushed commit id.
 
+Default to a conclusion plus a one-line rationale; do not restate what the diff or the resolved state already shows.
+
 Post to the `databaseId` of the thread's **first** comment — the reply endpoint takes a top-level comment id, not that of a reply: `gh api -X POST /repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -f body="..."`, or MCP `add_reply_to_pull_request_comment`.
 
 Do not resolve threads: review bots that verify fixes (e.g. coderabbitai) resolve their own threads once the pushed fix is verified, and all other threads are resolved manually outside this skill.

--- a/.claude/skills/copyedit/SKILL.md
+++ b/.claude/skills/copyedit/SKILL.md
@@ -14,8 +14,9 @@ For Japanese drafts, run the `textlint` skill first — it auto-fixes the mechan
 - **Facts** — check every concrete reference against its source: PR/issue numbers (`gh pr view`), commit ids (`git show`), file paths (Read/Glob), identifiers (Grep), numeric claims, and quotes (byte-for-byte). Names introduced by a proposed design must not be described as currently existing. Report anything uncheckable as "could not verify" — never pass it silently.
 - **Consistency** — one term per concept; no internal contradictions; terminology matches referenced specs; heading/list shapes consistent.
 - **Argument quality** — problem statements name the consequence, not just the fact ("X is duplicated, so a change needs two edits"); categorized lists partition cleanly.
-- **Reader perspective** — the reader has no chat history: no conversational references (「先ほど」「ご指摘の通り」); first-use terms defined in the document.
+- **Reader perspective** — the reader has no chat history: no conversational references (「先ほど」「ご指摘の通り」); first-use terms defined in the document. Relative references (「以前」「今後」, old/new contrasts) must name what they point at — a class, a method, a PR number, a commit id.
 - **Quantitative claims** — percentages cite the denominator N; numbers state their scope (time range, segment, version); causal language only with a named mechanism.
+- **Formatting** — hard-wrap only fixed-width destinations such as commit messages and code comments; never hard-wrap Markdown paragraphs.
 
 ## Report
 

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -5,7 +5,7 @@ description: Review the session for rule violations, analyze root causes, and cr
 
 # Retrospective
 
-Identify violations of `~/.claude/CLAUDE.md`, `~/.claude/rules/`, and skill workflows in this session, analyze root causes, and record countermeasures as a GitHub issue.
+Identify violations of `~/.claude/CLAUDE.md` and skill workflows in this session, analyze root causes, and record countermeasures as a GitHub issue.
 
 ## 1. Violations
 
@@ -21,12 +21,12 @@ Group related violations and classify each cause:
 
 ## 3. Countermeasures
 
-Always-on prompt text is a budget: every added rule loads into every future session, and this workflow is historically the main source of rule growth. Prefer countermeasures in this order:
+CLAUDE.md is a budget: every line added there loads into every future session, and this workflow is historically the main source of its growth. Prefer countermeasures in this order:
 
 1. **Mechanical enforcement** — settings.json permissions or hooks, a textlint/prh dictionary entry, or a script inside a skill. A deterministic check beats prose asking the model to be careful.
-2. **Skill fix** — correct the on-demand workflow that produced the violation; it loads only when invoked.
-3. **Rule deletion or simplification** — when the violation stems from conflicting or over-constraining rules.
-4. **Always-on rule addition (last resort)** — only when the mistake is expensive (data loss, leaking private context, destructive operations) and the model would not get it right from context alone; a line or two, never a new section.
+2. **Skill fix** — correct the on-demand workflow that produced the violation; it loads only when invoked. Guidance that applies to one kind of task belongs here even when no skill covers it yet — a new skill costs nothing until it is relevant.
+3. **Deletion or simplification** — when the violation stems from conflicting or over-constraining instructions.
+4. **CLAUDE.md addition (last resort)** — only when the mistake is expensive (data loss, leaking private context, destructive operations), spans every kind of task, and the model would not get it right from context alone; a line or two, never a new section.
 
 "No countermeasure" is a valid conclusion for a one-off failure unlikely to recur — record the violation and move on.
 

--- a/.claude/skills/textlint/SKILL.md
+++ b/.claude/skills/textlint/SKILL.md
@@ -14,7 +14,7 @@ Write the draft to a file, then run:
 
 Dependencies run via `npx` (pinned in `lint.sh`); the first run downloads them into the npx cache.
 
-Rules live in `.textlintrc.json` (preset-ja-technical-writing, preset-ai-writing, preset-ja-spacing, no-mixed-zenkaku-and-hankaku-alphabet) and `prh.yml` (katakana loanwords with established plain-Japanese equivalents, full-width parentheses). Context-dependent loanwords (ロジック, マッピング, クランプ, ラッパー) are intentionally absent from the dictionary — replace them yourself when no established technical term is intended.
+The target style is plain Japanese over katakana loanwords wherever a natural equivalent exists, half-width spaces around alphanumerics, code spans, and links, and half-width parentheses. Rules live in `.textlintrc.json` (preset-ja-technical-writing, preset-ai-writing, preset-ja-spacing, no-mixed-zenkaku-and-hankaku-alphabet) and `prh.yml` (katakana loanwords with established plain-Japanese equivalents, full-width parentheses). Context-dependent loanwords (ロジック, マッピング, クランプ, ラッパー) are intentionally absent from the dictionary — replace them yourself when no established technical term is intended.
 
 After `--fix`, review the remaining report: some rules (particle errors, sentence style) are detect-only and need manual edits.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Dotfiles Repository
 
-This repository is the source of truth for Claude Code configuration. `install.sh` deploys `.claude/` (CLAUDE.md, settings.json, rules, skills) to `~/.claude/`.
+This repository is the source of truth for Claude Code configuration. `install.sh` deploys `.claude/` (CLAUDE.md, settings.json, skills) to `~/.claude/`, and writes `~/.cursor/user-rules.md` for Cursor, which reads the skills from `~/.claude/skills/` directly.
+
+Instructions that only matter for a specific task belong in that task's skill rather than CLAUDE.md, which loads into every session.
 
 When modifying Claude configuration, always edit the source files under this repository's `.claude/` directory — never the deployed copies under `~/.claude/`. Commit the change, then run `install.sh` to deploy.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ Personal dotfiles for managing development environment configurations.
 
 ### Claude Code Configuration
 
-- **CLAUDE.md** - Professional engineering principles
-- **rules/** - Always-on rules applied across all conversations
-- **skills/** - Specialized capabilities for specific tasks
+- **CLAUDE.md** - Engineering principles, loaded into every session
+- **skills/** - Specialized capabilities, loaded only when a task calls for them
+
+Guidance that applies to one kind of task belongs in the skill that handles it, not in CLAUDE.md — skills stay out of context until they are relevant, and they are the one format other agents also read.
+
+### Cursor Configuration
+
+[Cursor loads skills](https://cursor.com/docs/skills) from `~/.claude/skills/` for compatibility with Claude Code, so a single install covers both tools.
+
+CLAUDE.md has no such counterpart: Cursor keeps [User Rules](https://cursor.com/docs/rules) in its settings rather than on disk, and there is no file-based way to apply instructions across every project. `install.sh` writes the text to `~/.cursor/user-rules.md`; paste it into **Customize → Rules → User Rules**. Cursor holds its own copy from then on, so paste it again after any install that changes the file — otherwise Cursor keeps running the previous version.
+
+The pasted text omits the priority rule that CLAUDE.md opens with, because Cursor resolves that conflict the other way round: project rules take precedence over user rules.
 
 ### mise Configuration
 
@@ -27,8 +36,11 @@ cd ~/dotfiles
 ```text
 ~/.claude/
 ├── CLAUDE.md
-├── rules/
+├── settings.json
 └── skills/
+
+~/.cursor/
+└── user-rules.md
 
 ~/.config/mise/
 └── config.toml

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,8 @@ set -e
 
 # Dotfiles Installer
 # This script installs:
-#   - Claude Code CLAUDE.md, settings.json, rules, and skills
+#   - Claude Code CLAUDE.md, settings.json, and skills
+#   - Cursor user rules, ready to paste into Customize → Rules
 #   - mise configuration
 # Run this script from the cloned repository directory
 
@@ -13,6 +14,8 @@ CLAUDE_DIR="$HOME/.claude"
 RULES_DIR="$CLAUDE_DIR/rules"
 SKILLS_DIR="$CLAUDE_DIR/skills"
 AGENTS_DIR="$CLAUDE_DIR/agents"
+CURSOR_DIR="$HOME/.cursor"
+CURSOR_USER_RULES="$CURSOR_DIR/user-rules.md"
 MISE_CONFIG_DIR="$HOME/.config/mise"
 
 echo "Installing dotfiles..."
@@ -25,10 +28,16 @@ if [ ! -d "$SOURCE_DIR" ]; then
     exit 1
 fi
 
-# Clean and recreate rules directory
-echo "🧹 Cleaning existing rules..."
-rm -rf "$RULES_DIR"
-mkdir -p "$RULES_DIR"
+mkdir -p "$CLAUDE_DIR"
+
+# Rules now live in CLAUDE.md and skills. Earlier runs left files behind that
+# would otherwise keep loading into every session — remove those by name so
+# rules added by hand stay, and drop the directory only once it is empty
+echo "🧹 Removing rules installed by earlier versions..."
+for legacy_rule in communication feedback-handling git tool-usage writing-style; do
+    rm -f "$RULES_DIR/$legacy_rule.md"
+done
+rmdir "$RULES_DIR" 2>/dev/null || true
 
 # Install CLAUDE.md
 echo "📝 Installing CLAUDE.md..."
@@ -37,15 +46,6 @@ cp "$SOURCE_DIR/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md"
 # Install settings.json
 echo "⚙️  Installing settings.json..."
 cp "$SOURCE_DIR/settings.json" "$CLAUDE_DIR/settings.json"
-
-# Install rules
-echo "📏 Installing rules..."
-for rule_file in "$SOURCE_DIR"/rules/*.md; do
-    if [ -f "$rule_file" ]; then
-        echo "   Installing rule: $(basename "$rule_file")"
-        cp "$rule_file" "$RULES_DIR"
-    fi
-done
 
 # Install skills
 echo ""
@@ -73,6 +73,26 @@ if [ -d "$SOURCE_DIR/agents" ]; then
         fi
     done
 fi
+
+echo ""
+
+# ============================================
+# Cursor configuration
+# ============================================
+echo "Installing Cursor configuration..."
+
+# Cursor loads skills from ~/.claude/skills/ for compatibility with Claude Code,
+# so the install above already covers them. Its always-on equivalent, User Rules,
+# is held in Cursor's settings rather than on disk, so the best that can be
+# installed is the text to paste in.
+# Priority Rules is dropped along the way: Cursor resolves the conflict the
+# other way round, giving project rules precedence over user rules
+mkdir -p "$CURSOR_DIR"
+awk '/^# /{ skip = ($0 == "# Priority Rules") } !skip' \
+    "$SOURCE_DIR/CLAUDE.md" > "$CURSOR_USER_RULES"
+echo "📋 Installed user rules: $CURSOR_USER_RULES"
+echo "   Paste its contents into Customize → Rules → User Rules — and again"
+echo "   after any install that changes them, since Cursor keeps its own copy."
 
 echo ""
 
@@ -105,11 +125,7 @@ echo ""
 echo "Installed files:"
 echo "  - $CLAUDE_DIR/CLAUDE.md"
 echo "  - $CLAUDE_DIR/settings.json"
-for rule_file in "$RULES_DIR"/*.md; do
-    if [ -f "$rule_file" ]; then
-        echo "  - $rule_file"
-    fi
-done
+echo "  - $CURSOR_USER_RULES"
 for skill_dir in "$SKILLS_DIR"/*/; do
     if [ -d "$skill_dir" ]; then
         echo "  - $skill_dir"


### PR DESCRIPTION
# Summary

Rules were a Claude Code-only construct, so nothing kept in `.claude/rules/` could ever reach Cursor. This folds every rule into either CLAUDE.md or the skill that needs it, retires `.claude/rules/`, and installs the one Cursor artifact that cannot be derived automatically.

# Motivation

Skills are the only instruction format that crosses agents. [Cursor loads them](https://cursor.com/docs/skills) from `~/.claude/skills/` for compatibility with Claude Code, so a rule moved into a skill starts working in both tools with no extra deployment step.

The move cuts context in Claude Code as well. [A rule without `paths` frontmatter](https://code.claude.com/docs/en/memory) loads into every session at the same priority as CLAUDE.md, so instructions that only apply while writing a commit message or replying to a review were charged against every unrelated session too.

What remains always-on has no file-based counterpart in Cursor: [user rules](https://cursor.com/docs/rules) live in its settings rather than on disk. The installer can only write out the text to paste in once.

# Changes

- Fold always-on guidance (communication style, pull request conventions) into CLAUDE.md and delete `.claude/rules/`
- Move task-specific guidance into the skill that owns it: review reply style into `address-comments`, Japanese prose style into `textlint`, reference and wrapping checks into `copyedit`
- Drop rules already covered by the model, by a skill description, or by `settings.json` permissions: tool preferences, destructive-command chaining, `/commit` invocation, `git -C`, retro deferral
- Rework the `retro` countermeasure ranking around CLAUDE.md as the budgeted surface, with skills as the default home for task-specific guidance
- Install `~/.cursor/user-rules.md` for pasting into Cursor's **Customize → Rules**
- Keep deleting `~/.claude/rules/` on install so files left by earlier versions stop loading
- State the "ask the user" rule without naming a Claude Code tool, so CLAUDE.md reads correctly in both tools

# Testing

Ran `install.sh` against an isolated `HOME` seeded with a stale `~/.claude/rules/`: the stale directory is removed, `~/.cursor/user-rules.md` matches `.claude/CLAUDE.md`, and a second run leaves no differences.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtmU4asqUjJLajUV2Y3bDR)_