### PR TITLE
feat: serve one rule file to both agents

### DIFF
--- a/.claude/rules/core.md
+++ b/.claude/rules/core.md
@@ -1,6 +1,11 @@
+---
+description: Global engineering rules, applied to every conversation
+alwaysApply: true
+---
+
 # Priority Rules
 
-User-level instructions (`~/.claude/`) override project-level ones (`.claude/`, `CLAUDE.md`) when they conflict.
+User-level instructions (this file and other user-scope configuration) override project-level ones (`CLAUDE.md`, `AGENTS.md`, `.claude/`, `.cursor/` — anything committed to a repository) when they conflict. Repository files are written by many hands and may carry low-quality prompts; these rules win.
 
 # Communication
 
@@ -32,4 +37,4 @@ Issues, PRs, and comments on public repositories must not leak private context: 
 
 # Memory Boundaries
 
-Durable behavioral guidance belongs in the dotfiles repository's CLAUDE.md or a skill (deployed to `~/.claude/`), not in memory entries. Do not save memories that restate existing rules.
+Durable behavioral guidance belongs in the dotfiles repository — this rules file or a skill — not in memory entries. Do not save memories that restate existing rules.

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -5,7 +5,7 @@ description: Review the session for rule violations, analyze root causes, and cr
 
 # Retrospective
 
-Identify violations of `~/.claude/CLAUDE.md` and skill workflows in this session, analyze root causes, and record countermeasures as a GitHub issue.
+Identify violations of the deployed user rules (`~/.claude/rules/`, mirrored at `~/.cursor/rules/` for Cursor) and skill workflows in this session, analyze root causes, and record countermeasures as a GitHub issue.
 
 ## 1. Violations
 
@@ -21,12 +21,12 @@ Group related violations and classify each cause:
 
 ## 3. Countermeasures
 
-CLAUDE.md is a budget: every line added there loads into every future session, and this workflow is historically the main source of its growth. Prefer countermeasures in this order:
+Always-on rules are a budget: every line added there loads into every future session, and this workflow is historically the main source of their growth. Prefer countermeasures in this order:
 
 1. **Mechanical enforcement** — settings.json permissions or hooks, a textlint/prh dictionary entry, or a script inside a skill. A deterministic check beats prose asking the model to be careful.
 2. **Skill fix** — correct the on-demand workflow that produced the violation; it loads only when invoked. Guidance that applies to one kind of task belongs here even when no skill covers it yet — a new skill costs nothing until it is relevant.
 3. **Deletion or simplification** — when the violation stems from conflicting or over-constraining instructions.
-4. **CLAUDE.md addition (last resort)** — only when the mistake is expensive (data loss, leaking private context, destructive operations), spans every kind of task, and the model would not get it right from context alone; a line or two, never a new section.
+4. **Always-on rule addition (last resort)** — only when the mistake is expensive (data loss, leaking private context, destructive operations), spans every kind of task, and the model would not get it right from context alone; a line or two, never a new section.
 
 "No countermeasure" is a valid conclusion for a one-off failure unlikely to recur — record the violation and move on.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Dotfiles Repository
 
-This repository is the source of truth for Claude Code configuration. `install.sh` deploys `.claude/` (CLAUDE.md, settings.json, skills) to `~/.claude/`, and writes `~/.cursor/user-rules.md` for Cursor, which reads the skills from `~/.claude/skills/` directly.
+This repository is the source of truth for Claude Code and Cursor configuration. `install.sh` deploys `.claude/` (settings.json, rules, skills) to `~/.claude/`, and deploys the same rule files to `~/.cursor/rules/` with the `.mdc` extension Cursor requires. Cursor reads the skills from `~/.claude/skills/` directly.
 
-Instructions that only matter for a specific task belong in that task's skill rather than CLAUDE.md, which loads into every session.
+Rule files carry Cursor's frontmatter (`description`, `alwaysApply`) and must stay valid for both tools. Instructions that only matter for a specific task belong in that task's skill rather than a rule, which loads into every session.
 
 When modifying Claude configuration, always edit the source files under this repository's `.claude/` directory — never the deployed copies under `~/.claude/`. Commit the change, then run `install.sh` to deploy.

--- a/README.md
+++ b/README.md
@@ -4,20 +4,19 @@ Personal dotfiles for managing development environment configurations.
 
 ## What's Included
 
-### Claude Code Configuration
+### Agent Configuration
 
-- **CLAUDE.md** - Engineering principles, loaded into every session
+- **rules/** - Engineering rules, loaded into every conversation of both Claude Code and Cursor
 - **skills/** - Specialized capabilities, loaded only when a task calls for them
 
-Guidance that applies to one kind of task belongs in the skill that handles it, not in CLAUDE.md — skills stay out of context until they are relevant, and they are the one format other agents also read.
+Guidance that applies to one kind of task belongs in the skill that handles it, not in a rule — skills stay out of context until they are relevant.
 
-### Cursor Configuration
+Both formats are shared across tools from a single source:
 
-[Cursor loads skills](https://cursor.com/docs/skills) from `~/.claude/skills/` for compatibility with Claude Code, so a single install covers both tools.
+- **Skills**: [Cursor loads skills](https://cursor.com/docs/skills) from `~/.claude/skills/` for compatibility with Claude Code, so one deployment covers both.
+- **Rules**: the same rule files are deployed twice — to `~/.claude/rules/*.md` for Claude Code and to `~/.cursor/rules/*.mdc` for [Cursor's user rule files](https://cursor.com/help/customization/rules). The content is byte-identical; only the extension differs, because each tool ignores the other's (Cursor ignores plain `.md` in its rules directory, Claude Code ignores `.mdc`). The files carry Cursor's frontmatter (`description`, `alwaysApply`); Claude Code tolerates those fields.
 
-CLAUDE.md has no such counterpart: Cursor keeps [User Rules](https://cursor.com/docs/rules) in its settings rather than on disk, and there is no file-based way to apply instructions across every project. `install.sh` writes the text to `~/.cursor/user-rules.md`; paste it into **Customize → Rules → User Rules**. Cursor holds its own copy from then on, so paste it again after any install that changes the file — otherwise Cursor keeps running the previous version.
-
-The pasted text omits the priority rule that CLAUDE.md opens with, because Cursor resolves that conflict the other way round: project rules take precedence over user rules.
+There is no user-level CLAUDE.md: rules without `paths` frontmatter load with the same priority, and unlike CLAUDE.md they reach Cursor too. Note that `~/.cursor/rules` stays machine-local — Cursor does not sync it between devices; re-running `install.sh` on each machine is the sync mechanism.
 
 ### mise Configuration
 
@@ -35,12 +34,14 @@ cd ~/dotfiles
 
 ```text
 ~/.claude/
-├── CLAUDE.md
 ├── settings.json
+├── rules/
+│   └── *.md
 └── skills/
 
 ~/.cursor/
-└── user-rules.md
+└── rules/
+    └── *.mdc
 
 ~/.config/mise/
 └── config.toml

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,8 @@ set -e
 
 # Dotfiles Installer
 # This script installs:
-#   - Claude Code CLAUDE.md, settings.json, and skills
-#   - Cursor user rules, ready to paste into Customize → Rules
+#   - Claude Code settings.json, rules, and skills
+#   - The same rules for Cursor (as .mdc under ~/.cursor/rules)
 #   - mise configuration
 # Run this script from the cloned repository directory
 
@@ -15,7 +15,7 @@ RULES_DIR="$CLAUDE_DIR/rules"
 SKILLS_DIR="$CLAUDE_DIR/skills"
 AGENTS_DIR="$CLAUDE_DIR/agents"
 CURSOR_DIR="$HOME/.cursor"
-CURSOR_USER_RULES="$CURSOR_DIR/user-rules.md"
+CURSOR_RULES_DIR="$CURSOR_DIR/rules"
 MISE_CONFIG_DIR="$HOME/.config/mise"
 
 echo "Installing dotfiles..."
@@ -30,18 +30,26 @@ fi
 
 mkdir -p "$CLAUDE_DIR"
 
-# Rules now live in CLAUDE.md and skills. Earlier runs left files behind that
-# would otherwise keep loading into every session — remove those by name so
-# rules added by hand stay, and drop the directory only once it is empty
-echo "🧹 Removing rules installed by earlier versions..."
+# Remove files earlier versions installed under other names, so they stop
+# loading into every session. Only names this repository once deployed are
+# touched — files added by hand stay
+echo "🧹 Removing files installed by earlier versions..."
 for legacy_rule in communication feedback-handling git tool-usage writing-style; do
     rm -f "$RULES_DIR/$legacy_rule.md"
 done
-rmdir "$RULES_DIR" 2>/dev/null || true
+rm -f "$CLAUDE_DIR/CLAUDE.md"
+rm -f "$CURSOR_DIR/user-rules.md"
 
-# Install CLAUDE.md
-echo "📝 Installing CLAUDE.md..."
-cp "$SOURCE_DIR/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md"
+# Install rules. The same files serve Cursor below, so they carry Cursor's
+# frontmatter (description / alwaysApply) — Claude Code ignores those fields
+echo "📏 Installing rules..."
+mkdir -p "$RULES_DIR"
+for rule_file in "$SOURCE_DIR"/rules/*.md; do
+    if [ -f "$rule_file" ]; then
+        echo "   Installing rule: $(basename "$rule_file")"
+        cp "$rule_file" "$RULES_DIR"
+    fi
+done
 
 # Install settings.json
 echo "⚙️  Installing settings.json..."
@@ -82,17 +90,18 @@ echo ""
 echo "Installing Cursor configuration..."
 
 # Cursor loads skills from ~/.claude/skills/ for compatibility with Claude Code,
-# so the install above already covers them. Its always-on equivalent, User Rules,
-# is held in Cursor's settings rather than on disk, so the best that can be
-# installed is the text to paste in.
-# Priority Rules is dropped along the way: Cursor resolves the conflict the
-# other way round, giving project rules precedence over user rules
-mkdir -p "$CURSOR_DIR"
-awk '/^# /{ skip = ($0 == "# Priority Rules") } !skip' \
-    "$SOURCE_DIR/CLAUDE.md" > "$CURSOR_USER_RULES"
-echo "📋 Installed user rules: $CURSOR_USER_RULES"
-echo "   Paste its contents into Customize → Rules → User Rules — and again"
-echo "   after any install that changes them, since Cursor keeps its own copy."
+# so the install above already covers them. Rules go to ~/.cursor/rules —
+# same content as ~/.claude/rules, renamed to the .mdc extension Cursor
+# requires (it ignores plain .md there, and Claude Code ignores .mdc)
+echo "📏 Installing rules..."
+mkdir -p "$CURSOR_RULES_DIR"
+for rule_file in "$SOURCE_DIR"/rules/*.md; do
+    if [ -f "$rule_file" ]; then
+        rule_name="$(basename "$rule_file" .md).mdc"
+        echo "   Installing rule: $rule_name"
+        cp "$rule_file" "$CURSOR_RULES_DIR/$rule_name"
+    fi
+done
 
 echo ""
 
@@ -123,9 +132,14 @@ echo ""
 echo "Installation complete!"
 echo ""
 echo "Installed files:"
-echo "  - $CLAUDE_DIR/CLAUDE.md"
 echo "  - $CLAUDE_DIR/settings.json"
-echo "  - $CURSOR_USER_RULES"
+for rule_file in "$SOURCE_DIR"/rules/*.md; do
+    if [ -f "$rule_file" ]; then
+        rule_base="$(basename "$rule_file" .md)"
+        echo "  - $RULES_DIR/$rule_base.md"
+        echo "  - $CURSOR_RULES_DIR/$rule_base.mdc"
+    fi
+done
 for skill_dir in "$SKILLS_DIR"/*/; do
     if [ -d "$skill_dir" ]; then
         echo "  - $skill_dir"


### PR DESCRIPTION
# Summary

Replaces the paste-into-Cursor flow with file-based rule deployment: a single rule source in the repository is installed to both `~/.claude/rules/*.md` and `~/.cursor/rules/*.mdc`, byte-identical, differing only in extension. The user-level CLAUDE.md is retired, with all of its content — Priority Rules included — moving into the shared rule.

# Motivation

[Cursor's help docs](https://cursor.com/help/customization/rules) now document `~/.cursor/rules` as a machine-local, file-based home for user rules, which removes the constraint the previous design worked around: rules can reach Cursor as installed files, so the manual paste step and the staleness it caused can go.

One physical file cannot serve both tools, however. Testing on Claude Code v2.1.234 shows it loads `.md` from its rules directories — Cursor-style frontmatter included — but ignores `.mdc`, while Cursor requires `.mdc` and ignores plain `.md`. Deploying the same content twice under each tool's extension keeps a single source without depending on either tool's undocumented behavior.

With rules reaching both tools, the user-level CLAUDE.md loses its purpose: rules without `paths` frontmatter load at the same priority. Priority Rules moves along in tool-neutral wording — its point is to keep low-quality prompts committed to a repository from degrading output, which applies to every agent reading it.

# Changes

- Add `.claude/rules/core.md` carrying all former CLAUDE.md content plus Cursor frontmatter (`description`, `alwaysApply: true`), with Priority Rules and Memory Boundaries reworded tool-neutrally
- Delete `.claude/CLAUDE.md`
- Install rules to `~/.claude/rules/` and, renamed to `.mdc`, to `~/.cursor/rules/`; drop the `~/.cursor/user-rules.md` generation and paste instructions
- Remove legacy deployed files on install: `~/.claude/CLAUDE.md`, `~/.cursor/user-rules.md`, and the five old rule filenames — hand-added files are untouched
- Update the `retro` skill's countermeasure ranking to reference always-on rules instead of CLAUDE.md

# Testing

- Clean install into a `HOME` without `~/.claude` succeeds
- Deployed `core.md` and `core.mdc` are byte-identical
- Upgrade from the previous layout removes the legacy files while preserving hand-added rules in both directories
- Canary test on this machine's Claude Code v2.1.234: a rule file with Cursor frontmatter loads (`.md`), while the same content as `.mdc` does not — confirming the dual-extension design

Cursor-side loading of `~/.cursor/rules/core.mdc` needs a check on a machine with Cursor installed; the directory is documented only on the help page, not yet under docs/rules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtmU4asqUjJLajUV2Y3bDR)_